### PR TITLE
Block movement to invalid nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ navigation.on('move', function (node) {
 })
 ```
 
+# F.A.Q
+
+> Q: A node that should be focusabled is never receiving focus - whats happening?
+
+A: Ensure that the parent nodes, etc. have the correct orientation in order to be able to jump inbetween nodes.
+
+> Q: All my parents have orientations, everything is setup in the navigation tree, and I STILL can't focus on the element.
+
+A: A node is considered invalid if it has 0 children AND no `selectAction` AND no orientation. 
+
+Make sure a node has at least 1 child, or a select action, or an orientation if you want it to be focusable. 
+
 ## Inspiration
 
 * [BBC - TV Application Layer (TAL)](http://bbc.github.io/tal/widgets/focus-management.html)

--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,6 @@ assign(Lrud.prototype, {
         return
       }
 
-      // blocks invalid content items from being focussed
       if (child.children.length <= 0 && child.selectAction == null && child.orientation == null) {
         return
       }

--- a/src/index.js
+++ b/src/index.js
@@ -257,6 +257,18 @@ assign(Lrud.prototype, {
       var nextActiveIndex = this._getNextActiveIndex(node, offset, activeIndex)
       var nextActiveChild = node.children[nextActiveIndex]
 
+      var child = this.nodes[nextActiveChild]
+
+      if (child == null) {
+        this._bubbleKeyEvent(event, node.parent)
+        return
+      }
+
+      // blocks invalid content items from being focussed
+      if (child.children.length <= 0 && child.selectAction == null && child.orientation == null) {
+        return
+      }
+
       if (nextActiveChild) {
         this._updateGrid(activeChild, nextActiveChild)
 


### PR DESCRIPTION
_Taken from the new FAQ_

> Q: All my parents have orientations, everything is setup in the navigation tree, and I STILL can't focus on the element.

A: A node is considered invalid if it has 0 children AND no `selectAction` AND no orientation. 

Make sure a node has at least 1 child, or a select action, or an orientation if you want it to be focusable. 

This work ensures the above