### PR TITLE
IPLAYERTV 8378 - LRUD Overrides

### DIFF
--- a/docs/ADRs/ADR-001-navigation-overrides.md
+++ b/docs/ADRs/ADR-001-navigation-overrides.md
@@ -33,3 +33,7 @@ Because the overrides live as a separate data item on an instance, and are check
 Approved
 
 ### Consequences
+
+- LRUD now "handles" more information than just a navigation tree. This is extra complexity, and as it is an extra data item, any LRUD implementation that currently moves data around will also have to move around the `overrides`
+
+- naive overrides can cause unexpected behaviour in LRUD itself. For example, setting an override target to `X` will _actually_ cause the final focus to end up on the first focusable child of `X`. While this does make sense, it can be somewhat unintuitive at first

--- a/src/index.js
+++ b/src/index.js
@@ -241,10 +241,14 @@ assign(Lrud.prototype, {
     if (!node) return
 
     var key = Lrud.KEY_CODES[event.keyCode]
-
+    var func = this._bubbleKeyEvent.bind(this)
     this.overrides.forEach(function (override) {
+      console.log('id', id)
+      console.log('override', override)
+      console.log('key', key)
+
       if (override.id === id && key === override.direction) {
-        return this._bubbleKeyEvent(event, override.target)
+        return func(event, override.target)
       }
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -253,48 +253,18 @@ assign(Lrud.prototype, {
       return
     }
 
-    console.log('node: ', node)
-
-    console.log(this.currentFocus)
-
-    // bind functions
-    var _updateGrid2 = this._updateGrid.bind(this)
-    var _emit2 = this.emit.bind(this)
-    var _newFocus2 = this.focus.bind(this)
-    var _activeChild2 = this._getActiveChild(node)
-    var _nodes2 = this.nodes
     var foundOverrides = false
-
-    this.overrides.forEach(function (override) {
+    var _myFunc = function (override) {
       if (override.id === id && key === override.direction) {
-        var targetNode = _nodes2[override.target]
-        console.log('Found a match')
-
-        _updateGrid2(_activeChild2, targetNode.id)
-
-        var moveEvent = assign({}, node, {
-          offset: offset,
-          enter: {
-            id: targetNode.id,
-            index: 0
-          },
-          leave: {
-            id: id,
-            index: 0
-          }
-        })
-
-        if (node.onMove) {
-          node.onMove(moveEvent)
-        }
-
-        _emit2('move', moveEvent)
-
-        _newFocus2(targetNode.id)
-        event.stopPropagation()
+        this._assignFocus(this._getActiveChild(node), override.target, 0, 0, 0, event, this.nodes[override.target])
         foundOverrides = true
       }
-    })
+    }
+
+    var myFunc = _myFunc.bind(this)
+
+    this.overrides.forEach(myFunc)
+
     if (foundOverrides) {
       return
     }
@@ -318,28 +288,7 @@ assign(Lrud.prototype, {
       }
 
       if (nextActiveChild) {
-        this._updateGrid(activeChild, nextActiveChild)
-
-        var moveEvent = assign({}, node, {
-          offset: offset,
-          enter: {
-            id: nextActiveChild,
-            index: nextActiveIndex
-          },
-          leave: {
-            id: activeChild,
-            index: activeIndex
-          }
-        })
-
-        if (node.onMove) {
-          node.onMove(moveEvent)
-        }
-
-        this.emit('move', moveEvent)
-
-        this.focus(nextActiveChild)
-        event.stopPropagation()
+        this._assignFocus(activeChild, nextActiveChild, nextActiveIndex, activeIndex, offset, event, node)
         return
       }
     }
@@ -347,6 +296,10 @@ assign(Lrud.prototype, {
     this._bubbleKeyEvent(event, node.parent)
   },
 
+  /**
+   *
+   * @param {*} id
+   */
   _bubbleActive: function (id) {
     var node = this.nodes[id]
 
@@ -374,7 +327,32 @@ assign(Lrud.prototype, {
     }
 
     self.register(id, props)
+  },
+
+  _assignFocus: function (activeChild, nextActiveChild, nextActiveIndex, activeIndex, offset, event, node) {
+    this._updateGrid(activeChild, nextActiveChild)
+    var moveEvent = assign({}, node, {
+      offset: offset,
+      enter: {
+        id: nextActiveChild,
+        index: nextActiveIndex
+      },
+      leave: {
+        id: activeChild,
+        index: activeIndex
+      }
+    })
+
+    if (node.onMove) {
+      node.onMove(moveEvent)
+    }
+
+    this.emit('move', moveEvent)
+
+    this.focus(nextActiveChild)
+    event.stopPropagation()
   }
+
 })
 
 Lrud.KEY_MAP = KeyCodes.map

--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,9 @@ function isValidLRUDEvent (event, node) {
   )
 }
 
-function Lrud () {
+function Lrud (params) {
   this.nodes = {}
+  this.overrides = params.overrides || []
   this.root = null
   this.currentFocus = null
 }
@@ -235,9 +236,16 @@ assign(Lrud.prototype, {
 
   _bubbleKeyEvent: function (event, id) {
     var node = this.nodes[id]
+    
     if (!node) return
-
+    
     var key = Lrud.KEY_CODES[event.keyCode]
+    
+    this.overrides.forEach(function (override) {
+      if (override.id === id && key === override.direction) {
+        return this._bubbleKeyEvent(event, override.target)
+      }
+    })
 
     if (key === Lrud.KEY_MAP.ENTER) {
       var clone = assign({}, node)

--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,7 @@ assign(Lrud.prototype, {
       var override = this.overrides[overrideId]
       if (!override) return
       if (override.id === id && key === override.direction) {
-        this._assignFocus(this._getActiveChild(node), override.target, 0, 0, 0, event, this.nodes[override.target])
+        this._assignFocus(this._getActiveChild(node), override.target, 0, node.children.indexOf(activeChild), 0, event, this.nodes[override.target])
         foundOverrides = true
       }
     }.bind(this)
@@ -345,12 +345,13 @@ assign(Lrud.prototype, {
   },
 
   /**
+   * assign focus from one child of a node to another
    *
    * @param {string} activeChildId id of the current active child of the node
    * @param {string} nextActiveChild id of the next child of the node to focus on
    * @param {number} nextActiveIndex index of the next child to focus on (index from the node.children array)
    * @param {number} activeIndex index of the current child (index from the node.children array)
-   * @param {number} offset 1 if moving right/down, -1 if moving left/up
+   * @param {number} offset 1 if moving right/down, -1 if moving left/up, 0 for override
    * @param {object} event the event that triggered the focus assignment
    * @param {object} node the navigation node we're acting on
    */

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ function isValidLRUDEvent (event, node) {
 }
 
 function Lrud (params) {
+  if (params == null) { params = [] }
   this.nodes = {}
   this.overrides = params.overrides || []
   this.root = null
@@ -236,11 +237,11 @@ assign(Lrud.prototype, {
 
   _bubbleKeyEvent: function (event, id) {
     var node = this.nodes[id]
-    
+
     if (!node) return
-    
+
     var key = Lrud.KEY_CODES[event.keyCode]
-    
+
     this.overrides.forEach(function (override) {
       if (override.id === id && key === override.direction) {
         return this._bubbleKeyEvent(event, override.target)

--- a/src/index.js
+++ b/src/index.js
@@ -263,8 +263,15 @@ assign(Lrud.prototype, {
 
     var foundOverrides = false
 
+    /**
+     * for a given overrideId, find that override from the this.override object
+     * if the override exists, and its id matches id and direction matches key, run _assignFocus
+     *
+     * @param {string} overrideId
+     */
     var handleOverride = function (overrideId) {
       var override = this.overrides[overrideId]
+      if (!override) return
       if (override.id === id && key === override.direction) {
         this._assignFocus(this._getActiveChild(node), override.target, 0, 0, 0, event, this.nodes[override.target])
         foundOverrides = true
@@ -337,16 +344,26 @@ assign(Lrud.prototype, {
     self.register(id, props)
   },
 
-  _assignFocus: function (activeChild, nextActiveChild, nextActiveIndex, activeIndex, offset, event, node) {
-    this._updateGrid(activeChild, nextActiveChild)
+  /**
+   *
+   * @param {string} activeChildId id of the current active child of the node
+   * @param {string} nextActiveChild id of the next child of the node to focus on
+   * @param {number} nextActiveIndex index of the next child to focus on (index from the node.children array)
+   * @param {number} activeIndex index of the current child (index from the node.children array)
+   * @param {number} offset 1 if moving right/down, -1 if moving left/up
+   * @param {object} event the event that triggered the focus assignment
+   * @param {object} node the navigation node we're acting on
+   */
+  _assignFocus: function (activeChildId, nextActiveChildId, nextActiveIndex, activeIndex, offset, event, node) {
+    this._updateGrid(activeChildId, nextActiveChildId)
     var moveEvent = assign({}, node, {
       offset: offset,
       enter: {
-        id: nextActiveChild,
+        id: nextActiveChildId,
         index: nextActiveIndex
       },
       leave: {
-        id: activeChild,
+        id: activeChildId,
         index: activeIndex
       }
     })
@@ -357,7 +374,7 @@ assign(Lrud.prototype, {
 
     this.emit('move', moveEvent)
 
-    this.focus(nextActiveChild)
+    this.focus(nextActiveChildId)
     event.stopPropagation()
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -241,16 +241,6 @@ assign(Lrud.prototype, {
     if (!node) return
 
     var key = Lrud.KEY_CODES[event.keyCode]
-    var func = this._bubbleKeyEvent.bind(this)
-    this.overrides.forEach(function (override) {
-      console.log('id', id)
-      console.log('override', override)
-      console.log('key', key)
-
-      if (override.id === id && key === override.direction) {
-        return func(event, override.target)
-      }
-    })
 
     if (key === Lrud.KEY_MAP.ENTER) {
       var clone = assign({}, node)
@@ -260,6 +250,52 @@ assign(Lrud.prototype, {
       }
 
       this.emit('select', clone)
+      return
+    }
+
+    console.log('node: ', node)
+
+    console.log(this.currentFocus)
+
+    // bind functions
+    var _updateGrid2 = this._updateGrid.bind(this)
+    var _emit2 = this.emit.bind(this)
+    var _newFocus2 = this.focus.bind(this)
+    var _activeChild2 = this._getActiveChild(node)
+    var _nodes2 = this.nodes
+    var foundOverrides = false
+
+    this.overrides.forEach(function (override) {
+      if (override.id === id && key === override.direction) {
+        var targetNode = _nodes2[override.target]
+        console.log('Found a match')
+
+        _updateGrid2(_activeChild2, targetNode.id)
+
+        var moveEvent = assign({}, node, {
+          offset: offset,
+          enter: {
+            id: targetNode.id,
+            index: 0
+          },
+          leave: {
+            id: id,
+            index: 0
+          }
+        })
+
+        if (node.onMove) {
+          node.onMove(moveEvent)
+        }
+
+        _emit2('move', moveEvent)
+
+        _newFocus2(targetNode.id)
+        event.stopPropagation()
+        foundOverrides = true
+      }
+    })
+    if (foundOverrides) {
       return
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,18 @@ function isValidLRUDEvent (event, node) {
   )
 }
 
+/**
+ *
+ * @param {object} params any params used used during instance construction
+ * @param {object} params.overrides any params used used during instance construction
+ * @param {string} params.overrides.id id of the node for an override to trigger on
+ * @param {string} params.overrides.direction direction for the override to trigger on
+ * @param {string} params.overrides.target node to set focus to after override triggered
+ */
 function Lrud (params) {
   if (params == null) { params = [] }
   this.nodes = {}
-  this.overrides = params.overrides || []
+  this.overrides = params.overrides || {}
   this.root = null
   this.currentFocus = null
 }
@@ -254,16 +262,16 @@ assign(Lrud.prototype, {
     }
 
     var foundOverrides = false
-    var _myFunc = function (override) {
+
+    var handleOverride = function (overrideId) {
+      var override = this.overrides[overrideId]
       if (override.id === id && key === override.direction) {
         this._assignFocus(this._getActiveChild(node), override.target, 0, 0, 0, event, this.nodes[override.target])
         foundOverrides = true
       }
-    }
+    }.bind(this)
 
-    var myFunc = _myFunc.bind(this)
-
-    this.overrides.forEach(myFunc)
+    Object.keys(this.overrides).forEach(handleOverride)
 
     if (foundOverrides) {
       return

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -13,7 +13,7 @@ describe('Given an instance of Lrud', () => {
     navigation = new Lrud()
   })
 
-  const noop = () => {}
+  const noop = () => { }
   const toJSON = (o) => JSON.parse(JSON.stringify(o))
 
   describe('register', () => {
@@ -49,7 +49,7 @@ describe('Given an instance of Lrud', () => {
       navigation.register('root')
       navigation.register('child', { parent: 'root' })
 
-      expect(navigation.nodes.root.children).toEqual([ 'child' ])
+      expect(navigation.nodes.root.children).toEqual(['child'])
       expect(navigation.nodes.child.parent).toEqual('root')
     })
 
@@ -346,10 +346,10 @@ describe('Given an instance of Lrud', () => {
 
       expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
       expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child4' }) ],
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
+        [expect.objectContaining({ id: 'child2' })],
+        [expect.objectContaining({ id: 'child4' })],
+        [expect.objectContaining({ id: 'child2' })],
+        [expect.objectContaining({ id: 'child1' })]
       ])
 
       expect(toJSON(moveSpy.mock.calls)).toEqual(data.horizontalMove)
@@ -381,10 +381,10 @@ describe('Given an instance of Lrud', () => {
 
       expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
       expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child4' }) ],
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
+        [expect.objectContaining({ id: 'child2' })],
+        [expect.objectContaining({ id: 'child4' })],
+        [expect.objectContaining({ id: 'child2' })],
+        [expect.objectContaining({ id: 'child1' })]
       ])
 
       expect(toJSON(moveSpy.mock.calls)).toEqual(data.verticalMove)
@@ -405,9 +405,9 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child1
 
       expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child3' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
+        [expect.objectContaining({ id: 'child2' })],
+        [expect.objectContaining({ id: 'child3' })],
+        [expect.objectContaining({ id: 'child1' })]
       ])
     })
 
@@ -431,10 +431,10 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 38, stopPropagation: noop }) // UP
 
       expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'row1-child2' }) ],
-        [ expect.objectContaining({ id: 'row2-child2' }) ],
-        [ expect.objectContaining({ id: 'row2-child3' }) ],
-        [ expect.objectContaining({ id: 'row1-child3' }) ]
+        [expect.objectContaining({ id: 'row1-child2' })],
+        [expect.objectContaining({ id: 'row2-child2' })],
+        [expect.objectContaining({ id: 'row2-child3' })],
+        [expect.objectContaining({ id: 'row1-child3' })]
       ])
     })
 
@@ -651,13 +651,13 @@ describe('Given an instance of Lrud', () => {
 
   describe('handleKeyEvent - with overrides', () => {
     it('should move through a horizontal list as expected [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'child2',
           direction: 'RIGHT',
           target: 'child1'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'horizontal' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
@@ -671,13 +671,13 @@ describe('Given an instance of Lrud', () => {
     })
 
     it('should move through a vertical list as expected [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'child1',
           direction: 'DOWN',
           target: 'child4'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'vertical' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
@@ -691,13 +691,13 @@ describe('Given an instance of Lrud', () => {
     })
 
     it('should move through a nested vertical list as expected [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'child3',
           direction: 'RIGHT',
           target: 'child4'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'vertical' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
@@ -711,13 +711,13 @@ describe('Given an instance of Lrud', () => {
     })
 
     it('should not move focus, ignoring override feature [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'child3',
           direction: 'DOWN',
           target: 'child4'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'vertical' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
@@ -731,13 +731,13 @@ describe('Given an instance of Lrud', () => {
     })
 
     it('should move down to a sub child of the parent element [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'child1',
           direction: 'RIGHT',
           target: 'child5'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'vertical' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
@@ -752,13 +752,13 @@ describe('Given an instance of Lrud', () => {
     })
 
     it('should correctly focus on the first focusable child of the specified override target [`override`]', () => {
-      navigation.overrides = [
-        {
+      navigation.overrides = {
+        'override-1': {
           id: 'keyboard',
           direction: 'DOWN',
           target: 'grid'
         }
-      ]
+      }
       navigation.register('root', { orientation: 'vertical' })
 
       // keyboard region

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -751,26 +751,40 @@ describe('Given an instance of Lrud', () => {
       expect(navigation.currentFocus).toEqual('child5')
     })
 
-    it('should move down to a sub child of the parent element [`override`]', () => {
+    it('should correctly focus on the first focusable child of the specified override target [`override`]', () => {
       navigation.overrides = [
         {
-          id: 'child1',
-          direction: 'RIGHT',
-          target: 'child5'
+          id: 'keyboard',
+          direction: 'DOWN',
+          target: 'grid'
         }
       ]
       navigation.register('root', { orientation: 'vertical' })
-      navigation.register('keyboard', { parent: 'root', selectAction: true })
-      navigation.register('grid', { parent: 'root', selectAction: true })
-      navigation.register('key-row-1', { parent: 'keyboard', selectAction: true })
-      navigation.register('key-row-2', { parent: 'keyboard', selectAction: true })
-      navigation.register('grid-row-1', { parent: 'grid', selectAction: true })
-      navigation.register('grid-row-2', { parent: 'grid', selectAction: true })
 
-      navigation.currentFocus = 'child1'
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+      // keyboard region
+      navigation.register('keyboard_region', { parent: 'root', orientation: 'vertical' })
+      navigation.register('keyboard', { parent: 'keyboard_region', orientation: 'vertical' })
+      navigation.register('key_row_1', { parent: 'keyboard', orientation: 'horizontal' })
+      navigation.register('key_row_2', { parent: 'keyboard', orientation: 'horizontal' })
+      navigation.register('key_row_1:button-a', { parent: 'key_row_1', selectAction: true })
+      navigation.register('key_row_1:button-b', { parent: 'key_row_1', selectAction: true })
+      navigation.register('key_row_2:button-c', { parent: 'key_row_2', selectAction: true })
+      navigation.register('key_row_2:button-d', { parent: 'key_row_2', selectAction: true })
 
-      expect(navigation.currentFocus).toEqual('child5')
+      // grid region
+      navigation.register('grid_region', { parent: 'root', orientation: 'vertical' })
+      navigation.register('grid', { parent: 'grid_region', orientation: 'vertical' })
+      navigation.register('grid_row_1', { parent: 'grid', orientation: 'horizontal' })
+      navigation.register('grid_row_2', { parent: 'grid', orientation: 'horizontal' })
+      navigation.register('grid_row_1:button-1', { parent: 'grid_row_1', selectAction: true })
+      navigation.register('grid_row_1:button-2', { parent: 'grid_row_1', selectAction: true })
+      navigation.register('grid_row_2:button-3', { parent: 'grid_row_2', selectAction: true })
+      navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true })
+
+      navigation.currentFocus = 'key_row_1:button-a'
+      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
     })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -650,7 +650,7 @@ describe('Given an instance of Lrud', () => {
   })
 
   describe('handleKeyEvent - with overrides', () => {
-    it.only('should move through a horizontal list as expected [`override`]', () => {
+    it('should move through a horizontal list as expected [`override`]', () => {
       navigation.overrides = [
         {
           id: 'child2',
@@ -665,21 +665,90 @@ describe('Given an instance of Lrud', () => {
       navigation.register('child4', { parent: 'root', selectAction: true })
 
       navigation.currentFocus = 'child2'
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
 
-      // // RIGHT
-      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child2
-      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child4
-      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Edge
-
-      // // LEFT
-      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child2
-      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child1
-      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Edge
-
-      // expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
       expect(navigation.currentFocus).toEqual('child1')
-      // expect(toJSON(moveSpy.mock.calls)).toEqual(data.horizontalMove)
+    })
+
+    it('should move through a vertical list as expected [`override`]', () => {
+      navigation.overrides = [
+        {
+          id: 'child1',
+          direction: 'DOWN',
+          target: 'child4'
+        }
+      ]
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'root', selectAction: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+
+      navigation.currentFocus = 'child1'
+      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('child4')
+    })
+
+    it('should move through a nested vertical list as expected [`override`]', () => {
+      navigation.overrides = [
+        {
+          id: 'child3',
+          direction: 'RIGHT',
+          target: 'child4'
+        }
+      ]
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'child1', selectAction: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+
+      navigation.currentFocus = 'child3'
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('child4')
+    })
+
+    it('should not move focus, ignoring override feature [`override`]', () => {
+      navigation.overrides = [
+        {
+          id: 'child3',
+          direction: 'DOWN',
+          target: 'child4'
+        }
+      ]
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'child1', selectAction: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+
+      navigation.currentFocus = 'child3'
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('child3')
+    })
+
+    it('should not move focus, ignoring override feature [`override`]', () => {
+      navigation.overrides = [
+        {
+          id: 'child1',
+          direction: 'RIGHT',
+          target: 'child5'
+        }
+      ]
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'child1', selectAction: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+      navigation.register('child5', { parent: 'child3', selectAction: true })
+
+      navigation.currentFocus = 'child1'
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('child5')
     })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -648,4 +648,97 @@ describe('Given an instance of Lrud', () => {
       expect(toJSON(navigation.nodes.root.children)).toEqual(['child-c', 'child-d'])
     })
   })
+
+  describe('handleKeyEvent - with overrides', () => {
+    it('should move through a horizontal list as expected', () => {
+      const stopPropagationSpy = jest.fn()
+      const focusSpy = jest.fn()
+      const moveSpy = jest.fn()
+
+      navigation.currentFocus = 'child1'
+      navigation.on('focus', focusSpy)
+      navigation.on('move', moveSpy)
+      navigation.register('root', { orientation: 'horizontal' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'root', selectAction: true, disabled: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+
+      // RIGHT
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child4
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Edge
+
+      // LEFT
+      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child1
+      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Edge
+
+      expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
+      expect(focusSpy.mock.calls).toEqual([
+        [ expect.objectContaining({ id: 'child2' }) ],
+        [ expect.objectContaining({ id: 'child4' }) ],
+        [ expect.objectContaining({ id: 'child2' }) ],
+        [ expect.objectContaining({ id: 'child1' }) ]
+      ])
+
+      expect(toJSON(moveSpy.mock.calls)).toEqual(data.horizontalMove)
+    })
+
+    it('should move through a vertical list as expected', () => {
+      const stopPropagationSpy = jest.fn()
+      const focusSpy = jest.fn()
+      const moveSpy = jest.fn()
+
+      navigation.currentFocus = 'child1'
+      navigation.on('focus', focusSpy)
+      navigation.on('move', moveSpy)
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'root', selectAction: true, disabled: true })
+      navigation.register('child4', { parent: 'root', selectAction: true })
+
+      // DOWN
+      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Focus child4
+      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Edge
+
+      // UP
+      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Focus child1
+      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Edge
+
+      expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
+      expect(focusSpy.mock.calls).toEqual([
+        [ expect.objectContaining({ id: 'child2' }) ],
+        [ expect.objectContaining({ id: 'child4' }) ],
+        [ expect.objectContaining({ id: 'child2' }) ],
+        [ expect.objectContaining({ id: 'child1' }) ]
+      ])
+
+      expect(toJSON(moveSpy.mock.calls)).toEqual(data.verticalMove)
+    })
+
+    it('should move through a wrapping list as expected', () => {
+      const focusSpy = jest.fn()
+
+      navigation.currentFocus = 'child1'
+      navigation.on('focus', focusSpy)
+      navigation.register('root', { orientation: 'horizontal', wrapping: true })
+      navigation.register('child1', { parent: 'root', selectAction: true })
+      navigation.register('child2', { parent: 'root', selectAction: true })
+      navigation.register('child3', { parent: 'root', selectAction: true })
+      // RIGHT
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child2
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child3
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child1
+
+      expect(focusSpy.mock.calls).toEqual([
+        [ expect.objectContaining({ id: 'child2' }) ],
+        [ expect.objectContaining({ id: 'child3' }) ],
+        [ expect.objectContaining({ id: 'child1' }) ]
+      ])
+    })
+  })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -651,94 +651,35 @@ describe('Given an instance of Lrud', () => {
 
   describe('handleKeyEvent - with overrides', () => {
     it('should move through a horizontal list as expected', () => {
-      const stopPropagationSpy = jest.fn()
-      const focusSpy = jest.fn()
-      const moveSpy = jest.fn()
-
-      navigation.currentFocus = 'child1'
-      navigation.on('focus', focusSpy)
-      navigation.on('move', moveSpy)
+      navigation.overrides = [
+        {
+          id: 'child2',
+          direction: 'RIGHT',
+          target: 'child1'
+        }
+      ]
       navigation.register('root', { orientation: 'horizontal' })
       navigation.register('child1', { parent: 'root', selectAction: true })
       navigation.register('child2', { parent: 'root', selectAction: true })
-      navigation.register('child3', { parent: 'root', selectAction: true, disabled: true })
-      navigation.register('child4', { parent: 'root', selectAction: true })
-
-      // RIGHT
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child2
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child4
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Edge
-
-      // LEFT
-      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child2
-      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child1
-      navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Edge
-
-      expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
-      expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child4' }) ],
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
-      ])
-
-      expect(toJSON(moveSpy.mock.calls)).toEqual(data.horizontalMove)
-    })
-
-    it('should move through a vertical list as expected', () => {
-      const stopPropagationSpy = jest.fn()
-      const focusSpy = jest.fn()
-      const moveSpy = jest.fn()
-
-      navigation.currentFocus = 'child1'
-      navigation.on('focus', focusSpy)
-      navigation.on('move', moveSpy)
-      navigation.register('root', { orientation: 'vertical' })
-      navigation.register('child1', { parent: 'root', selectAction: true })
-      navigation.register('child2', { parent: 'root', selectAction: true })
-      navigation.register('child3', { parent: 'root', selectAction: true, disabled: true })
-      navigation.register('child4', { parent: 'root', selectAction: true })
-
-      // DOWN
-      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Focus child2
-      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Focus child4
-      navigation.handleKeyEvent({ keyCode: 40, stopPropagation: stopPropagationSpy }) // Edge
-
-      // UP
-      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Focus child2
-      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Focus child1
-      navigation.handleKeyEvent({ keyCode: 38, stopPropagation: stopPropagationSpy }) // Edge
-
-      expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
-      expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child4' }) ],
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
-      ])
-
-      expect(toJSON(moveSpy.mock.calls)).toEqual(data.verticalMove)
-    })
-
-    it('should move through a wrapping list as expected', () => {
-      const focusSpy = jest.fn()
-
-      navigation.currentFocus = 'child1'
-      navigation.on('focus', focusSpy)
-      navigation.register('root', { orientation: 'horizontal', wrapping: true })
-      navigation.register('child1', { parent: 'root', selectAction: true })
-      navigation.register('child2', { parent: 'root', selectAction: true })
       navigation.register('child3', { parent: 'root', selectAction: true })
-      // RIGHT
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child2
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child3
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child1
+      navigation.register('child4', { parent: 'root', selectAction: true })
 
-      expect(focusSpy.mock.calls).toEqual([
-        [ expect.objectContaining({ id: 'child2' }) ],
-        [ expect.objectContaining({ id: 'child3' }) ],
-        [ expect.objectContaining({ id: 'child1' }) ]
-      ])
+      navigation.currentFocus = 'child2'
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop }) // Focus child2
+
+      // // RIGHT
+      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child2
+      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Focus child4
+      // navigation.handleKeyEvent({ keyCode: 39, stopPropagation: stopPropagationSpy }) // Edge
+
+      // // LEFT
+      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child2
+      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Focus child1
+      // navigation.handleKeyEvent({ keyCode: 37, stopPropagation: stopPropagationSpy }) // Edge
+
+      // expect(stopPropagationSpy).toHaveBeenCalledTimes(4)
+      expect(navigation.currentFocus).toEqual('child1')
+      // expect(toJSON(moveSpy.mock.calls)).toEqual(data.horizontalMove)
     })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -668,6 +668,7 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('child1')
+      expect(navigation.nodes.root.activeChild).toEqual('child1')
     })
 
     it('should move through a vertical list as expected [`override`]', () => {
@@ -688,6 +689,7 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('child4')
+      expect(navigation.nodes.root.activeChild).toEqual('child4')
     })
 
     it('should move through a nested vertical list as expected [`override`]', () => {
@@ -708,6 +710,7 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('child4')
+      expect(navigation.nodes.root.activeChild).toEqual('child4')
     })
 
     it('should not move focus, ignoring override feature [`override`]', () => {
@@ -746,9 +749,12 @@ describe('Given an instance of Lrud', () => {
       navigation.register('child5', { parent: 'child3', selectAction: true })
 
       navigation.currentFocus = 'child1'
+      navigation.setActiveChild('root', 'child1')
       navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('child5')
+      expect(navigation.nodes.root.activeChild).toEqual('child1')
+      expect(navigation.nodes.child3.activeChild).toEqual('child5')
     })
 
     it('should correctly focus on the first focusable child of the specified override target [`override`]', () => {
@@ -782,9 +788,17 @@ describe('Given an instance of Lrud', () => {
       navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true })
 
       navigation.currentFocus = 'key_row_1:button-a'
+      navigation.setActiveChild('root', 'keyboard_region')
+      navigation.setActiveChild('keyboard_region', 'keyboard')
+      navigation.setActiveChild('keyboard', 'key_row_1')
+      navigation.setActiveChild('key_row_1', 'key_row_1:button-a')
       navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
+      expect(navigation.nodes.root.activeChild).toEqual('grid_region')
+      expect(navigation.nodes.grid_region.activeChild).toEqual('grid')
+      expect(navigation.nodes.grid.activeChild).toEqual('grid_row_1')
+      expect(navigation.nodes.grid_row_1.activeChild).toEqual('grid_row_1:button-1')
     })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -730,7 +730,7 @@ describe('Given an instance of Lrud', () => {
       expect(navigation.currentFocus).toEqual('child3')
     })
 
-    it('should not move focus, ignoring override feature [`override`]', () => {
+    it('should move down to a sub child of the parent element [`override`]', () => {
       navigation.overrides = [
         {
           id: 'child1',
@@ -744,6 +744,28 @@ describe('Given an instance of Lrud', () => {
       navigation.register('child3', { parent: 'child1', selectAction: true })
       navigation.register('child4', { parent: 'root', selectAction: true })
       navigation.register('child5', { parent: 'child3', selectAction: true })
+
+      navigation.currentFocus = 'child1'
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+
+      expect(navigation.currentFocus).toEqual('child5')
+    })
+
+    it('should move down to a sub child of the parent element [`override`]', () => {
+      navigation.overrides = [
+        {
+          id: 'child1',
+          direction: 'RIGHT',
+          target: 'child5'
+        }
+      ]
+      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('keyboard', { parent: 'root', selectAction: true })
+      navigation.register('grid', { parent: 'root', selectAction: true })
+      navigation.register('key-row-1', { parent: 'keyboard', selectAction: true })
+      navigation.register('key-row-2', { parent: 'keyboard', selectAction: true })
+      navigation.register('grid-row-1', { parent: 'grid', selectAction: true })
+      navigation.register('grid-row-2', { parent: 'grid', selectAction: true })
 
       navigation.currentFocus = 'child1'
       navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -650,7 +650,7 @@ describe('Given an instance of Lrud', () => {
   })
 
   describe('handleKeyEvent - with overrides', () => {
-    it('should move through a horizontal list as expected', () => {
+    it.only('should move through a horizontal list as expected [`override`]', () => {
       navigation.overrides = [
         {
           id: 'child2',

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -799,6 +799,10 @@ describe('Given an instance of Lrud', () => {
       expect(navigation.nodes.grid_region.activeChild).toEqual('grid')
       expect(navigation.nodes.grid.activeChild).toEqual('grid_row_1')
       expect(navigation.nodes.grid_row_1.activeChild).toEqual('grid_row_1:button-1')
+
+      expect(navigation.nodes.keyboard_region.activeChild).toEqual('keyboard')
+      expect(navigation.nodes.keyboard.activeChild).toEqual('key_row_1')
+      expect(navigation.nodes.key_row_1.activeChild).toEqual('key_row_1:button-a')
     })
   })
 })


### PR DESCRIPTION
# Scenario

https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-8378

Work done by @benwdev and myself

We're introducing an "overrides" concept into LRUD.

The idea is contrary to a navigation tree, but we have a ton of scenarios whereby we need to jump between different nodes for specific behaviour as given by UX/Product, and this is a clean way to handle that.

Furthermore, because the overrides exist on the same level as navigation nodes but separate, they can be changed at runtime based on app state.

See tests for implementation usage

# Changelog

- `overrides` object so that each override can be named
- ADR explaining logic and reasoning