### PR TITLE
IPLAYERTVV1-8416 Updates to overrides system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 
 # Created by https://www.gitignore.io/api/node,macos
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ navigation.register('list-item-2', { parent: 'list' })
 
 ## Unregistering a node
 
-A node can be removed from the navigation tree by calling `navigation.unregister` with the id of the node
+A node can be removed from the navigation tree by calling `navigation.unregister()` with the id of the node
 
 ```js
 navigation.unregister('list-item-1')
@@ -133,13 +133,13 @@ navigation.unregister('list')
 ```
 
 ## Focus
-You can give focus to a particular node by calling `navigation.focus` with the node id
+You can give focus to a particular node by calling `navigation.focus()` with the node id
 
 ```js
 navigation.focus('list')
 ```
 
-Calling `navigation.focus` without an id will focus the root node
+Calling `navigation.focus()` without an id will focus the root node
 
 ```js
 navigation.focus()
@@ -207,6 +207,24 @@ navigation.on('move', function (node) {
   // node.enter - { id, index } of the node we're navigating into
   // node.leave - { id, index } of the node we're leaving
 })
+```
+
+## Overrides
+
+LRUD supports an override system, for times when correct product/UX behaviour requires focus to change in a way that is not strictly in accordance with the structure of the navigation tree.
+
+`navigation.overrides` is an object, each key representing an override object.
+
+The override object below represents that when LRUD is bubbling its key event, when it hits the `box-1` node, and direction of travel is `DOWN`, STOP the propogation of the bubble event and focus directly on `box-2`.
+
+```js
+navigation.overrides = {
+  'override-1': {           // the name of the override
+    'id': 'box-1',          // the ID to trigger the override on
+    'direction': 'DOWN',    // the direction of travel in order for the override to trigger
+    'target': 'box-2'       // the ID of the node we want to focus on
+  }
+}
 ```
 
 # F.A.Q

--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,7 @@ assign(Lrud.prototype, {
         var offset = (override.direction === 'RIGHT' || override.direction === 'DOWN') ? 1 : -1
         var nextActiveIndex = 0
         var activeIndex = 0
+        var overrideTargetParentId = this.nodes[this.nodes[override.target].parent].id
         if (this.nodes[override.target].parent != null) {
           nextActiveIndex = this.nodes[this.nodes[override.target].parent].children.indexOf(override.target)
         }
@@ -293,7 +294,7 @@ assign(Lrud.prototype, {
           offset, // offset
           event, // event
           this.nodes[override.target], // node,
-          this.nodes[this.nodes[override.target].parent].id, // an override for the move object id
+          overrideTargetParentId, // override node that we "moved through" to hit the enter.id
           override.id // an override for the move object leave.id
         )
         foundOverrides = true

--- a/src/index.js
+++ b/src/index.js
@@ -280,8 +280,8 @@ assign(Lrud.prototype, {
         this._assignFocus(
           this._getActiveChild(node), // activeChildId
           override.target, // nextActiveChild (becomes the enter.id for the move event)
-          0, // nextActiveIndex
-          node.children.indexOf(activeChild), // activeIndex
+          this.nodes[this.nodes[override.target].parent].children.indexOf(override.target), // nextActiveIndex
+          this.nodes[this.nodes[override.id].parent].children.indexOf(override.id), // activeIndex
           offset, // offset
           event, // event
           this.nodes[override.target], // node,
@@ -387,6 +387,9 @@ assign(Lrud.prototype, {
       moveEvent.id = moveId
       moveEvent.parent = this.nodes[moveId].parent
       moveEvent.children = this.nodes[moveId].children
+      if (this.nodes[moveId].activeChild) {
+        moveEvent.activeChild = this.nodes[moveId].activeChild
+      }
     }
 
     if (moveLeaveId != null) {

--- a/src/index.js
+++ b/src/index.js
@@ -276,12 +276,20 @@ assign(Lrud.prototype, {
       }
       if (override.id === id && key === override.direction) {
         var offset = (override.direction === 'RIGHT' || override.direction === 'DOWN') ? 1 : -1
+        var nextActiveIndex = 0
+        var activeIndex = 0
+        if (this.nodes[override.target].parent != null) {
+          nextActiveIndex = this.nodes[this.nodes[override.target].parent].children.indexOf(override.target)
+        }
+        if (this.nodes[override.id].parent != null) {
+          activeIndex = this.nodes[this.nodes[override.id].parent].children.indexOf(override.id)
+        }
 
         this._assignFocus(
           this._getActiveChild(node), // activeChildId
           override.target, // nextActiveChild (becomes the enter.id for the move event)
-          this.nodes[this.nodes[override.target].parent].children.indexOf(override.target), // nextActiveIndex
-          this.nodes[this.nodes[override.id].parent].children.indexOf(override.id), // activeIndex
+          nextActiveIndex,
+          activeIndex,
           offset, // offset
           event, // event
           this.nodes[override.target], // node,

--- a/src/index.js
+++ b/src/index.js
@@ -243,33 +243,6 @@ assign(Lrud.prototype, {
     return nextIndex
   },
 
-  /**
-   * when we're doing an override, we need to fake real behaviour which includes
-   * "bubbling up". therefore, we need to manually work out what the leave and id data
-   * should be
-   *
-   * for the given node we're acting on, we need to keep bubbling up until we find a node whose children
-   * contains target we're aiming for
-   *
-   * // leave needs to be the override.id - the thing we're leaving is from our override
-   * // node.id (mainNodeId) needs to be the parent that has the target as a child - we're moving
-   * across the thing that has the target as a parent
-   *
-   * @param {object} node node we're acting on
-   */
-  _getOverrideMoveInformation: function (node, override) {
-    var parentNode = this.nodes[this.nodes[override.target].parent]
-
-    if (parentNode && parentNode.children.indexOf(override.target) !== -1) {
-      return {
-        mainNodeId: parentNode.id,
-        leaveId: override.id
-      }
-    }
-
-    return this._getOverrideMoveInformation(parentNode, override)
-  },
-
   _bubbleKeyEvent: function (event, id) {
     var node = this.nodes[id]
 
@@ -412,6 +385,8 @@ assign(Lrud.prototype, {
 
     if (moveId != null) {
       moveEvent.id = moveId
+      moveEvent.parent = this.nodes[moveId].parent
+      moveEvent.children = this.nodes[moveId].children
     }
 
     if (moveLeaveId != null) {

--- a/src/index.js
+++ b/src/index.js
@@ -400,8 +400,6 @@ assign(Lrud.prototype, {
       node.onMove(moveEvent)
     }
 
-    console.log('moveEvent', moveEvent)
-
     this.emit('move', moveEvent)
 
     this.focus(nextActiveChildId)

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -813,11 +813,12 @@ describe('Given an instance of Lrud', () => {
 
       navigation.overrides = {
         'override-1': {
-          id: 'keyboard_region',
-          direction: 'RIGHT',
-          target: 'grid_region'
+          id: 'keyboard',
+          direction: 'DOWN',
+          target: 'grid'
         }
       }
+
       navigation.register('root', { orientation: 'vertical' })
 
       // keyboard region
@@ -842,12 +843,12 @@ describe('Given an instance of Lrud', () => {
 
       // so you're on the bottom row of a keyboard, in a keyboard region
       // pressing down should override you to land on the grid region
-      navigation.currentFocus = 'key_row_1:button-b'
+      navigation.currentFocus = 'key_row_1:button-a'
       navigation.setActiveChild('root', 'keyboard_region')
       navigation.setActiveChild('keyboard_region', 'keyboard')
       navigation.setActiveChild('keyboard', 'key_row_1')
       navigation.setActiveChild('key_row_1', 'key_row_1:button-a')
-      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
+      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
     })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -813,9 +813,9 @@ describe('Given an instance of Lrud', () => {
 
       navigation.overrides = {
         'override-1': {
-          id: 'keyboard',
-          direction: 'DOWN',
-          target: 'grid'
+          id: 'keyboard_region',
+          direction: 'RIGHT',
+          target: 'grid_region'
         }
       }
       navigation.register('root', { orientation: 'vertical' })
@@ -840,16 +840,16 @@ describe('Given an instance of Lrud', () => {
       navigation.register('grid_row_2:button-3', { parent: 'grid_row_2', selectAction: true })
       navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true })
 
-      navigation.currentFocus = 'key_row_1:button-a'
+      // so you're on the bottom row of a keyboard, in a keyboard region
+      // pressing down should override you to land on the grid region
+      navigation.currentFocus = 'key_row_1:button-b'
       navigation.setActiveChild('root', 'keyboard_region')
       navigation.setActiveChild('keyboard_region', 'keyboard')
       navigation.setActiveChild('keyboard', 'key_row_1')
       navigation.setActiveChild('key_row_1', 'key_row_1:button-a')
-      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
+      navigation.handleKeyEvent({ keyCode: 39, stopPropagation: noop })
 
-      // expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
-
-      // expect(onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'root' }))
+      expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
     })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -804,5 +804,52 @@ describe('Given an instance of Lrud', () => {
       expect(navigation.nodes.keyboard.activeChild).toEqual('key_row_1')
       expect(navigation.nodes.key_row_1.activeChild).toEqual('key_row_1:button-a')
     })
+
+    it.only('after an override, move event object should be built correctly [`override`]', () => {
+      const spy = jest.fn()
+      const onMove = jest.fn()
+
+      navigation.on('move', spy)
+
+      navigation.overrides = {
+        'override-1': {
+          id: 'keyboard',
+          direction: 'DOWN',
+          target: 'grid'
+        }
+      }
+      navigation.register('root', { orientation: 'vertical' })
+
+      // keyboard region
+      navigation.register('keyboard_region', { parent: 'root', orientation: 'vertical' })
+      navigation.register('keyboard', { parent: 'keyboard_region', orientation: 'vertical' })
+      navigation.register('key_row_1', { parent: 'keyboard', orientation: 'horizontal' })
+      navigation.register('key_row_2', { parent: 'keyboard', orientation: 'horizontal' })
+      navigation.register('key_row_1:button-a', { parent: 'key_row_1', selectAction: true })
+      navigation.register('key_row_1:button-b', { parent: 'key_row_1', selectAction: true })
+      navigation.register('key_row_2:button-c', { parent: 'key_row_2', selectAction: true })
+      navigation.register('key_row_2:button-d', { parent: 'key_row_2', selectAction: true })
+
+      // grid region
+      navigation.register('grid_region', { parent: 'root', orientation: 'vertical' })
+      navigation.register('grid', { parent: 'grid_region', orientation: 'vertical' })
+      navigation.register('grid_row_1', { parent: 'grid', orientation: 'horizontal' })
+      navigation.register('grid_row_2', { parent: 'grid', orientation: 'horizontal' })
+      navigation.register('grid_row_1:button-1', { parent: 'grid_row_1', selectAction: true })
+      navigation.register('grid_row_1:button-2', { parent: 'grid_row_1', selectAction: true })
+      navigation.register('grid_row_2:button-3', { parent: 'grid_row_2', selectAction: true })
+      navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true })
+
+      navigation.currentFocus = 'key_row_1:button-a'
+      navigation.setActiveChild('root', 'keyboard_region')
+      navigation.setActiveChild('keyboard_region', 'keyboard')
+      navigation.setActiveChild('keyboard', 'key_row_1')
+      navigation.setActiveChild('key_row_1', 'key_row_1:button-a')
+      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
+
+      // expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
+
+      // expect(onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'root' }))
+    })
   })
 })

--- a/test/lrud.test.js
+++ b/test/lrud.test.js
@@ -805,7 +805,7 @@ describe('Given an instance of Lrud', () => {
       expect(navigation.nodes.key_row_1.activeChild).toEqual('key_row_1:button-a')
     })
 
-    it.only('after an override, move event object should be built correctly [`override`]', () => {
+    it('after an override, move event object should have correct id [`override`]', () => {
       const spy = jest.fn()
       const onMove = jest.fn()
 
@@ -819,27 +819,27 @@ describe('Given an instance of Lrud', () => {
         }
       }
 
-      navigation.register('root', { orientation: 'vertical' })
+      navigation.register('root', { orientation: 'vertical', onMove })
 
       // keyboard region
-      navigation.register('keyboard_region', { parent: 'root', orientation: 'vertical' })
-      navigation.register('keyboard', { parent: 'keyboard_region', orientation: 'vertical' })
-      navigation.register('key_row_1', { parent: 'keyboard', orientation: 'horizontal' })
-      navigation.register('key_row_2', { parent: 'keyboard', orientation: 'horizontal' })
-      navigation.register('key_row_1:button-a', { parent: 'key_row_1', selectAction: true })
-      navigation.register('key_row_1:button-b', { parent: 'key_row_1', selectAction: true })
-      navigation.register('key_row_2:button-c', { parent: 'key_row_2', selectAction: true })
-      navigation.register('key_row_2:button-d', { parent: 'key_row_2', selectAction: true })
+      navigation.register('keyboard_region', { parent: 'root', orientation: 'vertical', onMove })
+      navigation.register('keyboard', { parent: 'keyboard_region', orientation: 'vertical', onMove })
+      navigation.register('key_row_1', { parent: 'keyboard', orientation: 'horizontal', onMove })
+      navigation.register('key_row_2', { parent: 'keyboard', orientation: 'horizontal', onMove })
+      navigation.register('key_row_1:button-a', { parent: 'key_row_1', selectAction: true, onMove })
+      navigation.register('key_row_1:button-b', { parent: 'key_row_1', selectAction: true, onMove })
+      navigation.register('key_row_2:button-c', { parent: 'key_row_2', selectAction: true, onMove })
+      navigation.register('key_row_2:button-d', { parent: 'key_row_2', selectAction: true, onMove })
 
       // grid region
-      navigation.register('grid_region', { parent: 'root', orientation: 'vertical' })
-      navigation.register('grid', { parent: 'grid_region', orientation: 'vertical' })
-      navigation.register('grid_row_1', { parent: 'grid', orientation: 'horizontal' })
-      navigation.register('grid_row_2', { parent: 'grid', orientation: 'horizontal' })
-      navigation.register('grid_row_1:button-1', { parent: 'grid_row_1', selectAction: true })
-      navigation.register('grid_row_1:button-2', { parent: 'grid_row_1', selectAction: true })
-      navigation.register('grid_row_2:button-3', { parent: 'grid_row_2', selectAction: true })
-      navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true })
+      navigation.register('grid_region', { parent: 'root', orientation: 'vertical', onMove })
+      navigation.register('grid', { parent: 'grid_region', orientation: 'vertical', onMove })
+      navigation.register('grid_row_1', { parent: 'grid', orientation: 'horizontal', onMove })
+      navigation.register('grid_row_2', { parent: 'grid', orientation: 'horizontal', onMove })
+      navigation.register('grid_row_1:button-1', { parent: 'grid_row_1', selectAction: true, onMove })
+      navigation.register('grid_row_1:button-2', { parent: 'grid_row_1', selectAction: true, onMove })
+      navigation.register('grid_row_2:button-3', { parent: 'grid_row_2', selectAction: true, onMove })
+      navigation.register('grid_row_2:button-4', { parent: 'grid_row_2', selectAction: true, onMove })
 
       // so you're on the bottom row of a keyboard, in a keyboard region
       // pressing down should override you to land on the grid region
@@ -851,6 +851,43 @@ describe('Given an instance of Lrud', () => {
       navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
 
       expect(navigation.currentFocus).toEqual('grid_row_1:button-1')
+      expect(onMove).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'grid_region', // is the parent of the override target
+        enter: { id: 'grid', index: 0 }, // node we entered with index of itself inside its parent
+        leave: { id: 'keyboard', index: 0 } // node we left with index of itself inside its parent
+      }))
+    })
+
+    it('after an override, move event object should have enter/leave indexes that are correct and greater than 0 [`override`]', () => {
+      const spy = jest.fn()
+      const onMove = jest.fn()
+
+      navigation.on('move', spy)
+
+      navigation.overrides = {
+        'override-1': {
+          id: 'button-a',
+          direction: 'DOWN',
+          target: 'button-d'
+        }
+      }
+      navigation.register('root', { orientation: 'vertical' })
+
+      navigation.register('row_region', { parent: 'root', orientation: 'vertical', onMove })
+      navigation.register('row', { parent: 'row_region', orientation: 'horizontal', onMove })
+      navigation.register('button-a', { parent: 'row', selectAction: true, onMove })
+      navigation.register('button-b', { parent: 'row', selectAction: true, onMove })
+      navigation.register('button-c', { parent: 'row', selectAction: true, onMove })
+      navigation.register('button-d', { parent: 'row', selectAction: true, onMove })
+
+      navigation.currentFocus = 'button-a'
+      navigation.handleKeyEvent({ keyCode: 20, stopPropagation: noop })
+
+      expect(onMove).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'row', // is the parent of the override target
+        enter: { id: 'button-d', index: 3 }, // node we entered with index of itself inside its parent
+        leave: { id: 'button-a', index: 0 } // node we left with index of itself inside its parent
+      }))
     })
   })
 })


### PR DESCRIPTION
# Scenario 

https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-8416

LRUD is currently is not firing correct `move` object data for an `onMove` event, when the move was completed via an override.

This piece of work is to ensure the data for an `onMove` callback is as correct as can be.

# Changelog

- updated readme
- added tests

Ensure the move object contains the correct;

- id
- enter id and index
- leave id and index
- parent
- children

