### PR TITLE
Error when registering an existing node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export class Lrud {
     }
 
     if (this.getNode(nodeId)) {
-      throw Error(`Node with an ID of ${nodeId} already exists`);
+      throw Error(`Node with an ID of ${nodeId} has already been registered`);
     }
 
     // if this is the very first node, set it as root and return...

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,10 @@ export class Lrud {
       node.id = nodeId
     }
 
+    if (this.getNode(nodeId)) {
+      throw Error(`Node with an ID of ${nodeId} already exists`);
+    }
+
     // if this is the very first node, set it as root and return...
     if (Object.keys(this.tree).length <= 0) {
       this.rootNodeId = nodeId

--- a/src/register.test.js
+++ b/src/register.test.js
@@ -104,4 +104,18 @@ describe('registerNode()', () => {
     expect(navigation.tree.root.children.b).not.toBeUndefined()
     expect(navigation.tree.root.children.c).not.toBeUndefined()
   })
+
+  test('registering a node that already exists should throw an error', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root')
+
+    const node = navigation.getNode('root')
+
+    expect(node.id).toEqual('root')
+
+    expect(() => {
+      navigation.registerNode('root')
+    }).toThrow()
+  })
 })


### PR DESCRIPTION
Fixes #9 

When registering a node with an ID, if that ID already exists in the tree, throw an exception.

Changelog

- new behaviour to throw an exception
- new test