### PR TITLE
Handle unregistering a node leaving no focusable node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,9 +246,11 @@ export class Lrud {
     if (parentNode.activeChild && parentNode.activeChild === nodeId) {
       delete parentNode.activeChild
       const top = this.climbUp(parentNode, '*')
-      const prev = this.getPrevChild(top)
-      const child = this.digDown(prev)
-      this.assignFocus(child.id)
+      if (top) {
+        const prev = this.getPrevChild(top)
+        const child = this.digDown(prev)
+        this.assignFocus(child.id)
+      }
     }
 
     // ...we need to recalculate the indexes of all the parents children

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -294,4 +294,14 @@ describe('unregisterNode()', () => {
     expect(navigation.tree).toMatchObject({})
     expect(navigation.overrides).toMatchObject({})
   })
+
+  test.only('unregistering the focused node when there is nothing else that can be focused on', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+    nav.registerNode('row1', { orientation: 'horizontal', parent: 'root' })
+    nav.registerNode('item1', { isFocusable: true, parent: 'row1' })
+
+    nav.unregisterNode('item1')
+  })
 })

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -311,4 +311,25 @@ describe('unregisterNode()', () => {
     expect(nav.getNode('root').activeChild).toEqual('row1')
     expect(nav.getNode('row1').activeChild).toEqual(undefined)
   })
+
+  test('unregistering the focused node when there is nothing else that can be focused on - more nesting', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+    nav.registerNode('boxa', { orientation: 'horizontal', parent: 'root' })
+    nav.registerNode('boxb', { orientation: 'horizontal', parent: 'boxa' })
+    nav.registerNode('boxc', { orientation: 'horizontal', parent: 'boxb' })
+    nav.registerNode('item1', { isFocusable: true, parent: 'boxc' })
+
+    // nothing else to focus on, but we shouldn't throw an exception
+    expect(() => {
+      nav.unregisterNode('item1')
+    }).not.toThrow()
+
+    // root should still have an activeChild of row 1
+    expect(nav.getNode('root').activeChild).toEqual('boxa')
+    expect(nav.getNode('boxa').activeChild).toEqual('boxb')
+    expect(nav.getNode('boxb').activeChild).toEqual('boxc')
+    expect(nav.getNode('boxc').activeChild).toEqual(undefined)
+  })
 })

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -295,13 +295,20 @@ describe('unregisterNode()', () => {
     expect(navigation.overrides).toMatchObject({})
   })
 
-  test.only('unregistering the focused node when there is nothing else that can be focused on', () => {
+  test('unregistering the focused node when there is nothing else that can be focused on', () => {
     const nav = new Lrud()
 
     nav.registerNode('root', { orientation: 'vertical' })
     nav.registerNode('row1', { orientation: 'horizontal', parent: 'root' })
     nav.registerNode('item1', { isFocusable: true, parent: 'row1' })
 
-    nav.unregisterNode('item1')
+    // nothing else to focus on, but we shouldn't throw an exception
+    expect(() => {
+      nav.unregisterNode('item1')
+    }).not.toThrow()
+
+    // root should still have an activeChild of row 1
+    expect(nav.getNode('root').activeChild).toEqual('row1')
+    expect(nav.getNode('row1').activeChild).toEqual(undefined)
   })
 })


### PR DESCRIPTION
Fixes #11 

Handles unregistering a node if there are no other nodes to focus on

Changelog

- only perform the "...and focus on something else" part of the process if we can find a `top` from the parent node of the thing we're unregistering
- tests