### PR TITLE
WIP: Feature/publish types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "Left, Right, Up, Down. A spatial navigation library for devices with input via directional controls",
   "main": "dist/index.min.js",
+  "types": "dist/index.d.ts",
   "homepage": "https://github.com/bbc/lrud",
   "license": "Apache-2.0",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true,
+        "declarationDir": "./dist",
         "moduleResolution": "node",
         "target": "es5",
         "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "declaration": true,
         "moduleResolution": "node",
         "target": "es5",
         "esModuleInterop": true,


### PR DESCRIPTION
Currently importing Lrud in a typescript project is no go as type definitions are not published.

Publish types so they can be used in a typescript project.

Rollup not publishing to dist yet...