### PR TITLE
Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "Left, Right, Up, Down. A spatial navigation library for devices with input via directional controls",
   "main": "dist/index.min.js",
+  "types": "dist/index.d.ts",
   "homepage": "https://github.com/bbc/lrud",
   "license": "Apache-2.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minify": "uglifyjs dist/index.js --compress --mangle -o dist/index.min.js",
     "prebuild": "npm run clean",
     "build": "rollup -c",
-    "postbuild": "npm run minify",
+    "postbuild": "npx tsc && npm run minify",
     "watch": "npm run build -- -w"
   }
 }

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -26,7 +26,6 @@ describe('event scenarios', () => {
     // only called once, as `left` is already the activeChild of `root`
     expect(activeSpy).toHaveBeenCalledWith({
       parent: 'left',
-      parents: ['left', 'root'],
       isFocusable: true,
       id: 'b',
       index: 1
@@ -58,7 +57,6 @@ describe('event scenarios', () => {
     expect(activeSpy.mock.calls).toEqual([
       [expect.objectContaining({
         parent: 'right',
-        parents: ['right', 'root'],
         isFocusable: true,
         id: 'd',
         index: 1
@@ -66,20 +64,17 @@ describe('event scenarios', () => {
       [expect.objectContaining({
         id: 'right',
         parent: 'root',
-        parents: ['root'],
         index: 1,
         activeChild: 'd',
         children: {
           c: {
             parent: 'right',
-            parents: ['right', 'root'],
             isFocusable: true,
             id: 'c',
             index: 0
           },
           d: {
             parent: 'right',
-            parents: ['right', 'root'],
             isFocusable: true,
             id: 'd',
             index: 1
@@ -91,28 +86,24 @@ describe('event scenarios', () => {
     expect(inactiveSpy.mock.calls).toEqual([
       [expect.objectContaining({
         parent: 'right',
-        parents: ['right', 'root'],
         isFocusable: true,
         id: 'c',
         index: 0
       })],
       [expect.objectContaining({
         id: 'left',
-        parents: ['root'],
         parent: 'root',
         index: 0,
         activeChild: 'a',
         children: {
           a: {
             parent: 'left',
-            parents: ['left', 'root'],
             isFocusable: true,
             id: 'a',
             index: 0
           },
           b: {
             parent: 'left',
-            parents: ['left', 'root'],
             isFocusable: true,
             id: 'b',
             index: 1
@@ -145,14 +136,12 @@ describe('event scenarios', () => {
         id: 'a',
         index: 0,
         parent: 'root',
-        parents: ['root'],
         isFocusable: true
       },
       enter: {
         id: 'b',
         index: 1,
         parent: 'root',
-        parents: ['root'],
         isFocusable: true
       },
       direction: 'RIGHT',
@@ -183,14 +172,12 @@ describe('event scenarios', () => {
         id: 'b',
         index: 1,
         parent: 'root',
-        parents: ['root'],
         isFocusable: true
       },
       enter: {
         id: 'a',
         index: 0,
         parent: 'root',
-        parents: ['root'],
         isFocusable: true
       },
       direction: 'LEFT',
@@ -215,11 +202,11 @@ describe('event scenarios', () => {
       .registerNode('d', { isFocusable: true })
 
     navigation.assignFocus('a')
-    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', parents: ['root'], index: 0 })
+    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
 
     navigation.assignFocus('b')
-    expect(blurSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', parents: ['root'], index: 0 })
-    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'b', parent: 'root', parents: ['root'], index: 1 })
+    expect(blurSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
+    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'b', parent: 'root', index: 1 })
   })
 
   test('standard blur and focus should fire after doing a move', () => {
@@ -239,12 +226,12 @@ describe('event scenarios', () => {
       .registerNode('d', { isFocusable: true })
 
     navigation.assignFocus('a')
-    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', parents: ['root'], index: 0 })
+    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
 
     navigation.handleKeyEvent({ direction: 'right' })
 
-    expect(blurSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', parents: ['root'], index: 0 })
-    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'b', parent: 'root', parents: ['root'], index: 1 })
+    expect(blurSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
+    expect(focusSpy).toHaveBeenCalledWith({ isFocusable: true, id: 'b', parent: 'root', index: 1 })
   })
 
   test('`onLeave` and `onEnter` functions should fire on a node', () => {

--- a/src/handle-key-event.test.js
+++ b/src/handle-key-event.test.js
@@ -80,7 +80,6 @@ describe('handleKeyEvent()', () => {
 
     expect(spy).toHaveBeenCalledWith({
       parent: 'root',
-      parents: ['root'],
       index: 1,
       id: 'child_2',
       isFocusable: true
@@ -92,7 +91,6 @@ describe('handleKeyEvent()', () => {
 
     expect(spy).toHaveBeenCalledWith({
       parent: 'root',
-      parents: ['root'],
       id: 'child_3',
       index: 2,
       isFocusable: true
@@ -116,7 +114,6 @@ describe('handleKeyEvent()', () => {
 
     expect(spy).toHaveBeenCalledWith({
       parent: 'root',
-      parents: ['root'],
       id: 'child_2',
       index: 1,
       isFocusable: true
@@ -128,7 +125,6 @@ describe('handleKeyEvent()', () => {
 
     expect(spy).toHaveBeenCalledWith({
       parent: 'root',
-      parents: ['root'],
       id: 'child_1',
       index: 0,
       isFocusable: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Get } from './get'
 import { Set } from './set'
-import { Node, Override } from './interfaces'
+import { Node, Override, KeyEvent } from './interfaces'
 
 import {
   isNodeFocusable,
@@ -585,7 +585,7 @@ export class Lrud {
    * @param {string} [event.keyCode]
    * @param {string} [event.direction]
    */
-  handleKeyEvent(event) {
+  handleKeyEvent(event: KeyEvent) {
     const direction = (event.keyCode) ? getDirectionForKeyCode(event.keyCode) : event.direction.toUpperCase()
     const currentFocusNode = this.getNode(this.currentFocusNodeId)
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,6 @@
 export interface Node {
     id: string;
     parent?: string;
-    parents?: string;
     index?: number;
     indexRange?: number[];
     selectAction?: Function;
@@ -19,4 +18,9 @@ export interface Override {
     id: string;
     direction: string;
     target: string;
+}
+
+export interface KeyEvent {
+    keyCode: number;
+    direction: string;
 }

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -69,7 +69,6 @@ describe('lrud', () => {
 
       expect(node2.selectAction).toEqual(12)
       expect(node2.parent).toEqual('BOX_A')
-      expect(node2.parents).toEqual(['BOX_A', 'root'])
       expect(navigation.tree.root.children['BOX_A'].children['NODE_2']).toBeUndefined()
     })
   })

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -116,7 +116,6 @@ describe('unregisterNode()', () => {
     // should trigger with the details of BOX_B
     expect(spy).toHaveBeenCalledWith({
       parent: 'root',
-      parents: ['root'],
       id: 'BOX_B',
       index: 1,
       activeChild: 'NODE_4',
@@ -124,20 +123,17 @@ describe('unregisterNode()', () => {
         NODE_4: {
           id: 'NODE_4',
           index: 0,
-          parent: 'BOX_B',
-          parents: ['BOX_B', 'root']
+          parent: 'BOX_B'
         },
         NODE_5: {
           id: 'NODE_5',
           index: 1,
-          parent: 'BOX_B',
-          parents: ['BOX_B', 'root']
+          parent: 'BOX_B'
         },
         NODE_6: {
           id: 'NODE_6',
           index: 2,
-          parent: 'BOX_B',
-          parents: ['BOX_B', 'root']
+          parent: 'BOX_B'
         }
       }
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "compilerOptions": {
+        "declaration": true,
+        "declarationDir": "dist",
+        "outDir": "dist",
         "moduleResolution": "node",
         "target": "es5",
         "esModuleInterop": true,


### PR DESCRIPTION
Adding some real types to LRUD

Changelog

- created an `interfaces` file and using said interfaces
- cleaned up logic around `node.parents` as its now redundant
    - tests have been updated to remove references to `parents` as well
- updated tsconfig to include declarations, plus output destinations
- updated build command to run `npx tsc`
