### PR TITLE
[Feature] register a tree into an instance (& misc. fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -478,30 +478,6 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
-      "dev": true
-    },
-    "@types/lodash.get": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
-      "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.set": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.6.tgz",
-      "integrity": "sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "11.13.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.8.tgz",
@@ -2183,25 +2159,29 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2211,13 +2191,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2227,37 +2209,43 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2266,25 +2254,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2293,13 +2285,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2315,7 +2309,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2329,13 +2324,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2344,7 +2341,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2353,7 +2351,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2363,19 +2362,22 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2384,13 +2386,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2399,13 +2403,15 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2415,7 +2421,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2424,7 +2431,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2433,13 +2441,15 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2450,7 +2460,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2468,7 +2479,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2478,13 +2490,15 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2494,7 +2508,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2506,19 +2521,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2527,19 +2545,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2549,19 +2570,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2573,7 +2597,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2581,7 +2606,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2596,7 +2622,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2605,43 +2632,50 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2652,7 +2686,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2661,7 +2696,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2670,13 +2706,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2691,13 +2729,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2706,13 +2746,15 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "@types/lodash.get": "^4.4.6",
-    "@types/lodash.set": "^4.3.6",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.11.0",
@@ -54,7 +52,7 @@
     "postversion": "git push && git push --tags",
     "clean": "rimraf dist",
     "lint": "eslint src/index.js",
-    "test": "jest",
+    "test": "npm run build && jest",
     "test:verbose": "jest --verbose",
     "minify": "uglifyjs dist/index.js --compress --mangle -o dist/index.min.js",
     "prebuild": "npm run clean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export class Lrud {
   /**
    * maintained for legacy API reasons
    */
-  register(nodeId: string, node: any = {}) {
+  register(nodeId: string, node: Node = { id: null }) {
     return this.registerNode(nodeId, node)
   }
 
@@ -744,5 +744,30 @@ export class Lrud {
     }
 
     this.emitter.emit('focus', node)
+  }
+
+  /**
+   * given an Lrud instance, copy all the data across from the other instance
+   * to this instance
+   * 
+   * @param {Lrud} otherInstance 
+   */
+  populateFrom(otherInstance: Lrud) {
+    const clone = (obj) => {
+      return JSON.parse(JSON.stringify(obj))
+    }
+
+    this.tree = clone(otherInstance.tree);
+    this.nodePathList = clone(otherInstance.nodePathList);
+    this.focusableNodePathList = clone(otherInstance.focusableNodePathList);
+    this.rootNodeId = clone(otherInstance.rootNodeId);
+    this.currentFocusNode = clone(otherInstance.currentFocusNode);
+    this.currentFocusNodeId = clone(otherInstance.currentFocusNodeId);
+    this.currentFocusNodeIndex = clone(otherInstance.currentFocusNodeIndex);
+    this.currentFocusNodeIndexRange = clone(otherInstance.currentFocusNodeIndexRange);
+    this.currentFocusNodeIndexRangeLowerBound = clone(otherInstance.currentFocusNodeIndexRangeLowerBound);
+    this.currentFocusNodeIndexRangeUpperBound = clone(otherInstance.currentFocusNodeIndexRangeUpperBound);
+    this.isIndexAlignMode = clone(otherInstance.isIndexAlignMode);
+    this.overrides = clone(otherInstance.overrides);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export class Lrud {
    * @param {string} [node.parent] if null, value of `this.rootNodeId` is used
    * @param {number} [node.index] if null, index is 1 more than the index of the last sibling. if no previous siblings, index is 1
    * @param {number[]} [node.indexRange] defaults to null. acts as a colspan, value [0] is lower bound, value [1] is upper bound
-   * @param {function} [node.selectAction] if a node has a selectAction, it is focusable
+   * @param {object} [node.selectAction] if a node has a selectAction, it is focusable
    * @param {boolean} [node.isFocusable] if a node is explicitly set as isFocusable, it is focusable
    * @param {boolean} [node.isWrapping] if true, when asking for the next child at the end or start of the node, the will "wrap around" and return the first/last (when asking for the last/first)
    * @param {string} [node.orientation] can be "vertical" or "horizontal". is used in conjuction when handling direction of key press, to determine which child is "next"
@@ -264,7 +264,7 @@ export class Lrud {
       nodeClone.onBlur(nodeClone);
     }
 
-    // if we have any overrides whose target is the node we just unregistered, we should unregister
+    // if we have any overrides whose target or ID is the node we just unregistered, we should unregister
     // those overrides (thus keeping state clean)
     Object.keys(this.overrides).forEach(overrideId => {
       const override = this.overrides[overrideId]
@@ -747,27 +747,37 @@ export class Lrud {
   }
 
   /**
-   * given an Lrud instance, copy all the data across from the other instance
-   * to this instance
+   * given a tree, return an array of Nodes in that tree
    * 
-   * @param {Lrud} otherInstance 
+   * @param {object} tree 
    */
-  populateFrom(otherInstance: Lrud) {
-    const clone = (obj) => {
-      return JSON.parse(JSON.stringify(obj))
+
+  getNodesFromTree(tree: object): Node[] {
+    const nodes: Node[] = []
+
+    const _getNodesFromTree = (tree) => {
+      Object.keys(tree).forEach(treeProperty => {
+        nodes.push({...tree[treeProperty], children: undefined });
+
+        if (tree[treeProperty].children) {
+          _getNodesFromTree(tree[treeProperty].children)
+        }
+      })
     }
 
-    this.tree = clone(otherInstance.tree);
-    this.nodePathList = clone(otherInstance.nodePathList);
-    this.focusableNodePathList = clone(otherInstance.focusableNodePathList);
-    this.rootNodeId = clone(otherInstance.rootNodeId);
-    this.currentFocusNode = clone(otherInstance.currentFocusNode);
-    this.currentFocusNodeId = clone(otherInstance.currentFocusNodeId);
-    this.currentFocusNodeIndex = clone(otherInstance.currentFocusNodeIndex);
-    this.currentFocusNodeIndexRange = clone(otherInstance.currentFocusNodeIndexRange);
-    this.currentFocusNodeIndexRangeLowerBound = clone(otherInstance.currentFocusNodeIndexRangeLowerBound);
-    this.currentFocusNodeIndexRangeUpperBound = clone(otherInstance.currentFocusNodeIndexRangeUpperBound);
-    this.isIndexAlignMode = clone(otherInstance.isIndexAlignMode);
-    this.overrides = clone(otherInstance.overrides);
+    _getNodesFromTree(tree);
+
+    return nodes;
+  }
+
+  /**
+   * given a tree, register all of its nodes into this instance
+   * 
+   * @param {object} tree 
+   */
+  registerTree(tree: object) {
+      this.getNodesFromTree(tree).forEach(node => {
+        this.registerNode(node.id, node)
+      })
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,9 +1,12 @@
+/**
+ * a node is both stored in the tree, and passed to functions to register nodes
+ */
 export interface Node {
     id: string;
     parent?: string;
     index?: number;
     indexRange?: number[];
-    selectAction?: Function;
+    selectAction?: any;
     isFocusable?: boolean;
     isWrapping?: boolean;
     orientation?: string;

--- a/src/multiple-instance-interaction.test.js
+++ b/src/multiple-instance-interaction.test.js
@@ -2,7 +2,7 @@
 
 const { Lrud } = require('./index')
 
-describe.only('registerTree()', () => {
+describe('registerTree()', () => {
   test('register a tree from one instance into another instance', () => {
     const Alpha = new Lrud()
     const Beta = new Lrud()

--- a/src/multiple-instance-interaction.test.js
+++ b/src/multiple-instance-interaction.test.js
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+
+const { Lrud } = require('./index')
+
+describe('populateFrom()', () => {
+  test('populating an instance from another should set that instance to be indentical for state data', () => {
+    const instanceA = new Lrud()
+    const instanceB = new Lrud()
+
+    instanceB.registerNode('root')
+    instanceB.registerNode('a', { isFocusable: true })
+    instanceB.registerNode('b', { isFocusable: true })
+    instanceB.assignFocus('a')
+
+    instanceA.populateFrom(instanceB)
+
+    expect(instanceA.tree.root.children.a).toBeTruthy()
+    expect(instanceA.tree.root.children.b).toBeTruthy()
+    expect(instanceA.nodePathList).toEqual([ 'root', 'root.children.a', 'root.children.b' ])
+    expect(instanceA.focusableNodePathList).toEqual([ 'root.children.a', 'root.children.b' ])
+    expect(instanceA.rootNodeId).toEqual('root')
+    expect(instanceA.currentFocusNode).toMatchObject({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
+    expect(instanceA.currentFocusNodeId).toEqual('a')
+    expect(instanceA.currentFocusNodeIndex).toEqual(0)
+    expect(instanceA.currentFocusNodeIndexRange).toEqual(null)
+    expect(instanceA.currentFocusNodeIndexRangeLowerBound).toEqual(0)
+    expect(instanceA.currentFocusNodeIndexRangeUpperBound).toEqual(0)
+    expect(instanceA.isIndexAlignMode).toEqual(false)
+    expect(instanceA.overrides).toEqual({})
+  })
+
+  test('when populateFrom(), changes to the receiver of data dont affect the original copied object', () => {
+    const instanceA = new Lrud()
+    const instanceB = new Lrud()
+
+    instanceB.registerNode('root')
+    instanceB.registerNode('a', { isFocusable: true })
+    instanceB.registerNode('b', { isFocusable: true })
+    instanceB.assignFocus('a')
+
+    instanceA.populateFrom(instanceB)
+
+    // now add new, DIFFERENT nodes to each
+    instanceA.registerNode('x', { isFocusable: true })
+    instanceB.registerNode('y', { isFocusable: true })
+
+    expect(instanceA.tree.root.children.x).toBeTruthy()
+    expect(instanceA.tree.root.children.y).not.toBeTruthy()
+
+    expect(instanceB.tree.root.children.x).not.toBeTruthy()
+    expect(instanceB.tree.root.children.y).toBeTruthy()
+  })
+})

--- a/src/multiple-instance-interaction.test.js
+++ b/src/multiple-instance-interaction.test.js
@@ -2,52 +2,22 @@
 
 const { Lrud } = require('./index')
 
-describe('populateFrom()', () => {
-  test('populating an instance from another should set that instance to be indentical for state data', () => {
-    const instanceA = new Lrud()
-    const instanceB = new Lrud()
+describe.only('registerTree()', () => {
+  test('register a tree from one instance into another instance', () => {
+    const Alpha = new Lrud()
+    const Beta = new Lrud()
 
-    instanceB.registerNode('root')
-    instanceB.registerNode('a', { isFocusable: true })
-    instanceB.registerNode('b', { isFocusable: true })
-    instanceB.assignFocus('a')
+    // register nodes against A
+    Alpha.registerNode('root')
+    Alpha.registerNode('a', { isFocusable: true })
+    Alpha.registerNode('b', { isFocusable: true })
 
-    instanceA.populateFrom(instanceB)
+    // register A's tree against B
+    Beta.registerTree(Alpha.tree)
 
-    expect(instanceA.tree.root.children.a).toBeTruthy()
-    expect(instanceA.tree.root.children.b).toBeTruthy()
-    expect(instanceA.nodePathList).toEqual([ 'root', 'root.children.a', 'root.children.b' ])
-    expect(instanceA.focusableNodePathList).toEqual([ 'root.children.a', 'root.children.b' ])
-    expect(instanceA.rootNodeId).toEqual('root')
-    expect(instanceA.currentFocusNode).toMatchObject({ isFocusable: true, id: 'a', parent: 'root', index: 0 })
-    expect(instanceA.currentFocusNodeId).toEqual('a')
-    expect(instanceA.currentFocusNodeIndex).toEqual(0)
-    expect(instanceA.currentFocusNodeIndexRange).toEqual(null)
-    expect(instanceA.currentFocusNodeIndexRangeLowerBound).toEqual(0)
-    expect(instanceA.currentFocusNodeIndexRangeUpperBound).toEqual(0)
-    expect(instanceA.isIndexAlignMode).toEqual(false)
-    expect(instanceA.overrides).toEqual({})
-  })
-
-  test('when populateFrom(), changes to the receiver of data dont affect the original copied object', () => {
-    const instanceA = new Lrud()
-    const instanceB = new Lrud()
-
-    instanceB.registerNode('root')
-    instanceB.registerNode('a', { isFocusable: true })
-    instanceB.registerNode('b', { isFocusable: true })
-    instanceB.assignFocus('a')
-
-    instanceA.populateFrom(instanceB)
-
-    // now add new, DIFFERENT nodes to each
-    instanceA.registerNode('x', { isFocusable: true })
-    instanceB.registerNode('y', { isFocusable: true })
-
-    expect(instanceA.tree.root.children.x).toBeTruthy()
-    expect(instanceA.tree.root.children.y).not.toBeTruthy()
-
-    expect(instanceB.tree.root.children.x).not.toBeTruthy()
-    expect(instanceB.tree.root.children.y).toBeTruthy()
+    // B should now have the correct nodes in its tree
+    expect(Beta.tree.root).toBeTruthy()
+    expect(Beta.tree.root.children.a).toBeTruthy()
+    expect(Beta.tree.root.children.b).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Description
Using Lrud in engineering spikes has revealed a clear and definite desire for the ability to take an LRUD tree as raw JSON data, and to register that entire tree against a different LRUD instance.

Basically, a smart clone of an Lrud tree.

## How Has This Been Tested?
New tests added in `src/multiple-instance-interaction.test.js`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
