### PR TITLE
[Feature] Partial tree insertion

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -210,6 +210,119 @@ navigation.overrides = {
   }
 }
 ```
+
+# Tree and Partial Tree Insertion & Registering
+
+LRUD supports the ability to register an entire tree at once.
+
+```js
+const instance = new Lrud();
+const tree = {
+  root: {
+    orientation: 'horizontal',
+    children: {
+      alpha: { isFocusable: true },
+      beta: { isFocusable: true },
+      charlie: { isFocusable: true },
+    }
+  }
+}
+
+instance.registerTree(tree);
+// `instance` now has the above tree registered, and has correctly setup active children, indexes, etc. 
+```
+
+## `insertTree()` and nested tree registration
+
+LRUD also supports the ability to register a tree/insert a tree into an already existing branch.
+
+If no parent is given on the top level node of the passed tree, the tree will be inserted under the root node, as per standard `registerNode()` behaviour.
+
+Otherwise, if a `parent` _is_ given, the tree will be inserted under that parent.
+
+### Inserting a tree under the root node
+```js
+const instance = new Lrud();
+instance
+  .registerNode('root', { orientation: 'horizontal' })
+  .registerNode('alpha', { isFocusable: true })
+  .registerNode('beta', { isFocusable: true })
+
+const tree = {
+  charlie: {
+    orientation: 'vertical',
+    children: {
+      charlie_1: { isFocusable: true },
+      charlie_2: { isFocusable: true },
+    }
+  }
+}
+instance.registerTree(tree);
+/*
+the full tree of `instance` now looks like:
+{
+  root: {
+    orientation: 'horizontal',
+    children: {
+      alpha: { isFocusable: true }
+      beta: { isFocusable: true }
+      charlie: {
+        orientation: 'vertical'
+        children: {
+          charlie_1: { isFocusable: true }
+          charlie_2: { isFocusable: true }
+        }
+      }
+    }
+  }
+}
+*/
+```
+
+### Inserting a tree under a specified branch
+
+```js
+const instance = new Lrud();
+instance
+  .registerNode('root', { orientation: 'horizontal' })
+  .registerNode('alpha', { isFocusable: true })
+  .registerNode('beta', { orientation: 'vertical' })
+
+const tree = {
+  charlie: {
+    orientation: 'vertical',
+    parent: 'beta',
+    children: {
+      charlie_1: { isFocusable: true },
+      charlie_2: { isFocusable: true },
+    }
+  }
+}
+instance.registerTree(tree);
+/*
+the full tree of `instance` now looks like:
+{
+  root: {
+    orientation: 'horizontal',
+    children: {
+      alpha: { isFocusable: true }
+      beta: {
+        orientation: 'vertical',
+        children: {
+          charlie: {
+            orientation: 'vertical'
+            children: {
+              charlie_1: { isFocusable: true }
+              charlie_2: { isFocusable: true }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+*/
+```
 # F.A.Q
 
 > Q: A node that should be focusabled is never receiving focus - whats happening?

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export class Lrud {
    * @param {function} [node.onLeave] if a node has an `onLeave` function, it will be run when a move event leaves this node
    * @param {function} [node.onEnter] if a node has an `onEnter` function, it will be run when a move event enters this node
    */
-  registerNode(nodeId: string, node: Node) {
+  registerNode(nodeId: string, node: Node = {}) {
     if (!node.id) {
       node.id = nodeId
     }
@@ -191,7 +191,7 @@ export class Lrud {
   /**
    * maintained for legacy API reasons
    */
-  register(nodeId: string, node: Node) {
+  register(nodeId: string, node: Node = {}) {
     return this.registerNode(nodeId, node)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Get } from './get'
 import { Set } from './set'
-import { Node, Override, KeyEvent } from './interfaces'
+import { Node, Override, KeyEvent, InsertTreeOptions } from './interfaces'
 
 import {
   isNodeFocusable,
@@ -9,7 +9,8 @@ import {
   isNodeInPaths,
   _findChildWithMatchingIndexRange,
   _findChildWithClosestIndex,
-  _findChildWithIndex
+  _findChildWithIndex,
+  getNodesFromTree
 } from './utils'
 
 import mitt from 'mitt'
@@ -50,6 +51,10 @@ export class Lrud {
    * @param {object} node
    */
   reindexChildrenOfNode(node: Node) {
+    if (!node) {
+      return;
+    }
+
     if (!node.children) {
       return
     }
@@ -124,7 +129,7 @@ export class Lrud {
    * @param {function} [node.onLeave] if a node has an `onLeave` function, it will be run when a move event leaves this node
    * @param {function} [node.onEnter] if a node has an `onEnter` function, it will be run when a move event enters this node
    */
-  registerNode(nodeId: string, node: Node = { id: null }) {
+  registerNode(nodeId: string, node: Node) {
     if (!node.id) {
       node.id = nodeId
     }
@@ -186,7 +191,7 @@ export class Lrud {
   /**
    * maintained for legacy API reasons
    */
-  register(nodeId: string, node: Node = { id: null }) {
+  register(nodeId: string, node: Node) {
     return this.registerNode(nodeId, node)
   }
 
@@ -752,32 +757,57 @@ export class Lrud {
    * @param {object} tree 
    */
 
-  getNodesFromTree(tree: object): Node[] {
-    const nodes: Node[] = []
-
-    const _getNodesFromTree = (tree) => {
-      Object.keys(tree).forEach(treeProperty => {
-        nodes.push({...tree[treeProperty], children: undefined });
-
-        if (tree[treeProperty].children) {
-          _getNodesFromTree(tree[treeProperty].children)
-        }
-      })
-    }
-
-    _getNodesFromTree(tree);
-
-    return nodes;
-  }
-
   /**
    * given a tree, register all of its nodes into this instance
    * 
    * @param {object} tree 
    */
   registerTree(tree: object) {
-      this.getNodesFromTree(tree).forEach(node => {
+      getNodesFromTree(tree).forEach(node => {
         this.registerNode(node.id, node)
       })
+  }
+
+  /**
+   * given a tree object, attempt to register that tree into the current lrud instance
+   * 
+   * if the given tree already exists as a branch in the instance tree, the new tree will replace that branch
+   * 
+   * if the new tree doesn't already exist as a branch in the instance tree, this function will register the new
+   * tree as a branch against the root node, as per standard registerNode() behaviour
+   * 
+   * @param {object} tree
+   * @param {object} options
+   * @param {object} options.maintainIndex if true, and new tree is replacing an existing branch of the tree, maintain the original branches relative index
+   */
+  insertTree(tree: object, options: InsertTreeOptions = { maintainIndex: true }) {
+    const replacementNode = tree[Object.keys(tree)[0]]
+
+    if (!replacementNode.id) {
+      replacementNode.id = Object.keys(tree)[0]
+    }
+
+    const originalNode = this.pickNode(replacementNode.id);
+    if (!replacementNode.parent && originalNode && originalNode.parent) {
+      replacementNode.parent = originalNode.parent
+    }
+
+    const parentNode = this.getNode(replacementNode.parent);
+
+    if (options.maintainIndex && originalNode && originalNode.index) {
+      replacementNode.index = originalNode.index
+      Object.keys(parentNode.children).forEach(childId => {
+        const child = parentNode.children[childId]
+        if (child.index >= originalNode.index) {
+          child.index += 1;
+        }
+      })
+    }
+
+    this.registerTree(tree);
+    
+    if (options.maintainIndex) {
+      this.reindexChildrenOfNode(parentNode);
+    }
   }
 }

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -136,4 +136,69 @@ describe('insertTree()', () => {
     expect(instance.tree['root'].children['charlie'].index).toEqual(1)
     expect(instance.tree['root'].children['beta'].index).toEqual(2)
   })
+
+  test('insert a tree under the root node of the existing tree, as no parent given on the top node of the tree', () => {
+    const tree = {
+      charlie: {
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    const instance = new Lrud()
+
+    instance
+      .registerNode('root', { orientation: 'horizontal' })
+      .registerNode('alpha', { isFocusable: true })
+      .registerNode('beta', { isFocusable: true })
+
+    instance.insertTree(tree)
+
+    expect(instance.tree['root'].children['alpha']).toBeTruthy()
+    expect(instance.tree['root'].children['beta']).toBeTruthy()
+    expect(instance.tree['root'].children['charlie']).toBeTruthy()
+    expect(instance.tree['root'].children['charlie'].children).toBeTruthy()
+
+    expect(instance.tree['root'].children['alpha'].index).toEqual(0)
+    expect(instance.tree['root'].children['beta'].index).toEqual(1)
+    expect(instance.tree['root'].children['charlie'].index).toEqual(2)
+  })
+
+  test('insert a tree under a branch that ISNT the root node', () => {
+    const tree = {
+      charlie: {
+        parent: 'beta',
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    const instance = new Lrud()
+
+    instance
+      .registerNode('root', { orientation: 'horizontal' })
+      .registerNode('alpha', { isFocusable: true })
+      .registerNode('beta', { orientation: 'vertical' })
+
+    instance.insertTree(tree)
+
+    expect(instance.tree['root'].children['alpha']).toBeTruthy()
+    expect(instance.tree['root'].children['beta']).toBeTruthy()
+    expect(instance.tree['root'].children['beta'].children['charlie']).toBeTruthy()
+    expect(instance.tree['root'].children['beta'].children['charlie'].children).toBeTruthy()
+  })
 })

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -1,0 +1,139 @@
+/* eslint-env jest */
+const { Lrud } = require('./index')
+
+describe('insertTree()', () => {
+  test('insert a simple tree into an empty instance', () => {
+    const instance = new Lrud()
+    const tree = {
+      root: {
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    instance.insertTree(tree)
+    instance.assignFocus('node_a')
+
+    expect(instance.tree['root']).toBeTruthy()
+    expect(instance.tree['root'].children['node_a']).toBeTruthy()
+    expect(instance.tree['root'].children['node_b']).toBeTruthy()
+    expect(instance.currentFocusNodeId).toEqual('node_a')
+  })
+
+  test('insert a simple tree into an existing branch of lrud', () => {
+    const tree = {
+      alpha: {
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    const instance = new Lrud()
+
+    instance
+      .registerNode('root', { orientation: 'horizontal' })
+      .registerNode('alpha', { isFocusable: true })
+      .registerNode('beta', { isFocusable: true })
+
+    expect(instance.tree['root']).toBeTruthy()
+    expect(instance.tree['root'].children['alpha']).toBeTruthy()
+    expect(instance.tree['root'].children['alpha'].isFocusable).toEqual(true)
+    expect(instance.tree['root'].children['alpha'].children).toEqual(undefined)
+    expect(instance.tree['root'].children['beta']).toBeTruthy()
+    expect(instance.tree['root'].children['beta'].isFocusable).toEqual(true)
+    expect(instance.tree['root'].children['beta'].children).toEqual(undefined)
+
+    instance.insertTree(tree)
+
+    expect(instance.tree['root']).toBeTruthy()
+    expect(instance.tree['root'].children['alpha']).toBeTruthy()
+    expect(instance.tree['root'].children['alpha'].children['node_a'].isFocusable).toEqual(true)
+    expect(instance.tree['root'].children['alpha'].children['node_b'].isFocusable).toEqual(true)
+    expect(instance.tree['root'].children['beta']).toBeTruthy()
+    expect(instance.tree['root'].children['beta'].isFocusable).toEqual(true)
+    expect(instance.tree['root'].children['beta'].children).toEqual(undefined)
+  })
+
+  test('simple tree, inserting into existing branch, maintain index order', () => {
+    const tree = {
+      beta: {
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    const instance = new Lrud()
+
+    instance
+      .registerNode('root', { orientation: 'horizontal' })
+      .registerNode('alpha', { isFocusable: true })
+      .registerNode('beta', { isFocusable: true })
+      .registerNode('charlie', { isFocusable: true })
+
+    expect(instance.tree['root'].children['alpha'].index).toEqual(0)
+    expect(instance.tree['root'].children['beta'].index).toEqual(1)
+    expect(instance.tree['root'].children['charlie'].index).toEqual(2)
+
+    instance.insertTree(tree)
+
+    expect(instance.tree['root'].children['alpha'].index).toEqual(0)
+    expect(instance.tree['root'].children['beta'].index).toEqual(1)
+    expect(instance.tree['root'].children['charlie'].index).toEqual(2)
+  })
+
+  test('simple tree, inserting into existing branch, DONT maintain index order', () => {
+    const tree = {
+      beta: {
+        orientation: 'horizontal',
+        children: {
+          node_a: {
+            isFocusable: true
+          },
+          node_b: {
+            isFocusable: true
+          }
+        }
+      }
+    }
+
+    const instance = new Lrud()
+
+    instance
+      .registerNode('root', { orientation: 'horizontal' })
+      .registerNode('alpha', { isFocusable: true })
+      .registerNode('beta', { isFocusable: true })
+      .registerNode('charlie', { isFocusable: true })
+
+    expect(instance.tree['root'].children['alpha'].index).toEqual(0)
+    expect(instance.tree['root'].children['beta'].index).toEqual(1)
+    expect(instance.tree['root'].children['charlie'].index).toEqual(2)
+
+    instance.insertTree(tree, { maintainIndex: false })
+
+    // note that beta is now at the end, as it was picked and re-inserted
+    expect(instance.tree['root'].children['alpha'].index).toEqual(0)
+    expect(instance.tree['root'].children['charlie'].index).toEqual(1)
+    expect(instance.tree['root'].children['beta'].index).toEqual(2)
+  })
+})

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,3 +27,7 @@ export interface KeyEvent {
     keyCode: number;
     direction: string;
 }
+
+export interface InsertTreeOptions {
+    maintainIndex: boolean;
+}

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -62,7 +62,7 @@ describe('unregisterNode()', () => {
     ])
   })
 
-  test('if unregistering the focused node, recalcualte focus', () => {
+  test('if unregistering the focused node, recalculate focus', () => {
     const navigation = new Lrud()
 
     navigation.registerNode('root', { orientation: 'horizontal' })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -462,7 +462,7 @@ describe('_findChildWithIndex()', () => {
   })
 })
 
-describe.only('isNodeInTree()', () => {
+describe('isNodeInTree()', () => {
   test('node is in tree at top level, return true', () => {
     const tree = {
       root: {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -8,7 +8,8 @@ const {
   isNodeInPaths,
   _findChildWithMatchingIndexRange,
   _findChildWithClosestIndex,
-  _findChildWithIndex
+  _findChildWithIndex,
+  isNodeInTree
 } = require('./utils')
 
 describe('Closest()', () => {
@@ -458,5 +459,86 @@ describe('_findChildWithIndex()', () => {
 
     const found = _findChildWithIndex(node, 5)
     expect(found).toEqual(null)
+  })
+})
+
+describe.only('isNodeInTree()', () => {
+  test('node is in tree at top level, return true', () => {
+    const tree = {
+      root: {
+        children: {
+          node_a: true,
+          node_b: true
+        }
+      }
+    }
+
+    expect(isNodeInTree('root', tree)).toEqual(true)
+  })
+
+  test('node is at bottom level, return true', () => {
+    const tree = {
+      root: {
+        children: {
+          node_a: true,
+          node_b: {
+            children: {
+              node_c: true,
+              node_d: {
+                children: {
+                  node_e: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(isNodeInTree('node_e', tree)).toEqual(true)
+  })
+
+  test('node is nested, return true', () => {
+    const tree = {
+      root: {
+        children: {
+          node_a: true,
+          node_b: {
+            children: {
+              node_c: true,
+              node_d: {
+                children: {
+                  node_e: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(isNodeInTree('node_c', tree)).toEqual(true)
+  })
+
+  test('node is not present, return false', () => {
+    const tree = {
+      root: {
+        children: {
+          node_a: true,
+          node_b: {
+            children: {
+              node_c: true,
+              node_d: {
+                children: {
+                  node_e: true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(isNodeInTree('node_x', tree)).toEqual(false)
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,11 +179,12 @@ export const getNodesFromTree = (tree: object): Node[] => {
 
     const _getNodesFromTree = (tree, parent) => {
         Object.keys(tree).forEach(treeProperty => {
+            let _parent = tree[treeProperty].parent || parent
             nodes.push({
                 ...tree[treeProperty],
                 id: treeProperty,
                 children: undefined,
-                parent
+                parent: _parent
             });
 
             if (tree[treeProperty].children) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { KeyCodes } from './key-codes'
+import { Node } from './interfaces'
 
 /**
  * given an array of values and a goal, return the value from values which is closest to the goal
@@ -151,4 +152,46 @@ export const _findChildWithIndex = (node, index) => {
     }
 
     return null
+}
+
+export const isNodeInTree = (nodeId: string, tree: object) => {
+    let nodeInTree: boolean = false;
+
+    const _isNodeInTree = (tree) => {
+        Object.keys(tree).forEach(treeProperty => {
+            if (nodeId === treeProperty) {
+                nodeInTree = true;
+            }
+
+            if (tree[treeProperty].children) {
+                _isNodeInTree(tree[treeProperty].children)
+            }
+        })
+    }
+
+    _isNodeInTree(tree);
+
+    return nodeInTree;
+}
+
+export const getNodesFromTree = (tree: object): Node[] => {
+    const nodes: Node[] = []
+
+    const _getNodesFromTree = (tree, parent) => {
+        Object.keys(tree).forEach(treeProperty => {
+            nodes.push({
+                ...tree[treeProperty],
+                id: treeProperty,
+                children: undefined,
+                parent
+            });
+
+            if (tree[treeProperty].children) {
+                _getNodesFromTree(tree[treeProperty].children, treeProperty)
+            }
+        })
+    }
+
+    _getNodesFromTree(tree, undefined);
+    return nodes;
 }


### PR DESCRIPTION
## Description
Feature to support the insertion of a partial LRUD tree in JSON form into an existing LRUD instance.

## Motivation and Context
In order to support the use cases we want, the engineering spike at https://github.com/bbc/ssr-refactor-spike surfaced a desire to be able to easily insert partial navigation trees, as per the trees that would come down from an SSR response.

This PR includes that behaviour and tests around it.

## How Has This Been Tested?
Tested locally using https://github.com/bbc/ssr-refactor-spike and new test files

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
