### PR TITLE
[Fix] Turn off `isIndexAlignMode` when unregistering a focused node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,9 +248,7 @@ export class Lrud {
     // ...if we're unregistering the activeChild of our parent (could be a leaf OR branch)
     // we need to recalculate the focus...
     if (parentNode.activeChild && parentNode.activeChild === nodeId) {
-      if (this.isIndexAlignMode) {
-        this.isIndexAlignMode = false;
-      }
+      this.isIndexAlignMode = false;
       delete parentNode.activeChild
       const top = this.climbUp(parentNode, '*')
       if (top) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,9 @@ export class Lrud {
     // ...if we're unregistering the activeChild of our parent (could be a leaf OR branch)
     // we need to recalculate the focus...
     if (parentNode.activeChild && parentNode.activeChild === nodeId) {
+      if (this.isIndexAlignMode) {
+        this.isIndexAlignMode = false;
+      }
       delete parentNode.activeChild
       const top = this.climbUp(parentNode, '*')
       if (top) {


### PR DESCRIPTION
## Description
When we're unregistering a node, we should turn off `isIndexAlignMode` if we're unregistering something we're focused on.

This makes the behaviour of "find the last prev thing you CAN focus on" a lot more natural and easy to understand from a user P.O.V

## Motivation and Context
Realised this behaviour seems very odd and counter-intuitive when using LRUD in the TTR spike.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
