### PR TITLE
[Fix] When unregistering the root node, reset all relevant instance state.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,16 @@ import mitt from 'mitt'
 
 export class Lrud {
   tree: any;
-  nodePathList: any;
-  focusableNodePathList: any;
-  rootNodeId: any;
+  nodePathList: string[];
+  focusableNodePathList: string[];
+  rootNodeId: string;
   currentFocusNode: any;
-  currentFocusNodeId: any;
-  currentFocusNodeIndex: any;
-  currentFocusNodeIndexRange: any;
-  currentFocusNodeIndexRangeLowerBound: any;
-  currentFocusNodeIndexRangeUpperBound: any;
-  isIndexAlignMode: any;
+  currentFocusNodeId: string;
+  currentFocusNodeIndex: number;
+  currentFocusNodeIndexRange: number[];
+  currentFocusNodeIndexRangeLowerBound: number;
+  currentFocusNodeIndexRangeUpperBound: number;
+  isIndexAlignMode: boolean;
   emitter: mitt.Emitter
   overrides: any;
 
@@ -213,7 +213,16 @@ export class Lrud {
   unregisterNode(nodeId: string) {
     if (nodeId === this.rootNodeId) {
       this.tree = {}
-      this.overrides = {};
+      this.nodePathList = []
+      this.focusableNodePathList = [];
+      this.rootNodeId = null
+      this.currentFocusNode = null
+      this.currentFocusNodeId = null
+      this.currentFocusNodeIndex = null
+      this.currentFocusNodeIndexRange = null
+      this.isIndexAlignMode = false
+      this.emitter = new mitt();
+      this.overrides = {}
       return;
     }
 

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -328,4 +328,48 @@ describe('unregisterNode()', () => {
     expect(nav.getNode('boxb').activeChild).toEqual('boxc')
     expect(nav.getNode('boxc').activeChild).toEqual(undefined)
   })
+
+  test('unregistering the root node and re-registering should give a clean tree', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', {
+      orientation: 'horizontal'
+    })
+    nav.registerNode('node1', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+    nav.registerNode('container', {
+      orientation: 'vertical',
+      parent: 'node1'
+    })
+    nav.registerNode('item', {
+      selectAction: {},
+      parent: 'container'
+    })
+
+    nav.unregisterNode('root')
+
+    nav.registerNode('root', {
+      orientation: 'horizontal'
+    })
+    nav.registerNode('node2', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+    nav.registerNode('container', {
+      orientation: 'vertical',
+      parent: 'node2'
+    })
+    nav.registerNode('item', {
+      selectAction: {},
+      parent: 'container'
+    })
+
+    expect(nav.tree['root']).toBeTruthy()
+    expect(nav.tree['root'].children['node2']).toBeTruthy()
+    expect(nav.tree['root'].children['node2'].children['container']).toBeTruthy()
+    expect(nav.tree['root'].children['node2'].children['container'].children['item']).toBeTruthy()
+    expect(nav.tree['root'].children['node1']).toBeFalsy()
+  })
 })


### PR DESCRIPTION
## Description
When unregistering the root node, the tree is now effectively empty, so reset all relevant state.

## Motivation and Context
Issue was raised that noticed if the root node had children and was then unregistered, if it was re-registered with the same name it could cause the unregistered children to come back.

Fixes #19 

This was due to internal pathing state.

## How Has This Been Tested?
New test case for the supplied reproduction scenario in #19 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
