### PR TITLE
[Feature] Unregister options

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,6 +148,14 @@ If an unregister causes the current focused node to be removed, focus will be mo
 
 Unregistering the root node will cause the tree to become empty and also remove all overrides that have been set (see Overrides, below).
 
+### Unregistering Options
+
+A config object can be given to `unregisterNode(<nodeId>, <unregisterOptions>)` to force specific behaviour.
+
+- `forceRefocus:boolean` When `true`, the default behaviour of finding a new node to focus on if unregistering the current
+  focused node will continue to work as normal. This value also defaults to `true`. Pass as `false` to stop the auto-refocus
+  behaviour. Remember, if you are unregistering the current focused node, and passing `forceRefocus` as `false`, you need to manually call `assignFocus()` afterwards or the user will be left in limbo!
+
 ## Assigning Focus
 
 You can give focus to a particular node by calling `navigation.assignFocus()` with the node id

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Get } from './get'
 import { Set } from './set'
-import { Node, Override, KeyEvent, InsertTreeOptions } from './interfaces'
+import { Node, Override, KeyEvent, InsertTreeOptions, UnregisterNodeOptions} from './interfaces'
 
 import {
   isNodeFocusable,
@@ -201,16 +201,18 @@ export class Lrud {
    * 
    * @param {string} nodeId
    */
-  unregister(nodeId: string) {
-    this.unregisterNode(nodeId);
+  unregister(nodeId: string, unregisterOptions?: UnregisterNodeOptions) {
+    this.unregisterNode(nodeId, unregisterOptions);
   }
 
   /**
    * unregister a node from the navigation tree
    * 
    * @param {string} nodeId
+   * @param {object} unregisterOptions
+   * @param {boolean} unregisterOptions.forceRefocus if true, LRUD will attempt to re-focus on a new node if the currently focused node becomes unregistered due to the given node ID being unregistered
    */
-  unregisterNode(nodeId: string) {
+  unregisterNode(nodeId: string, unregisterOptions: UnregisterNodeOptions = { forceRefocus: true }) {
     if (nodeId === this.rootNodeId) {
       this.tree = {}
       this.nodePathList = []
@@ -261,13 +263,20 @@ export class Lrud {
     if (parentNode.activeChild && parentNode.activeChild === nodeId) {
       this.isIndexAlignMode = false;
       delete parentNode.activeChild
-      const top = this.climbUp(parentNode, '*')
-      if (top) {
-        const prev = this.getPrevChild(top)
-        if (isNodeFocusable(prev) || (prev && prev.children && Object.keys(prev.children).length)) {
-          const child = this.digDown(prev)
-          this.assignFocus(child.id)
+
+      if (unregisterOptions.forceRefocus) {
+        const top = this.climbUp(parentNode, '*')
+        if (top) {
+          const prev = this.getPrevChild(top)
+          if (isNodeFocusable(prev) || (prev && prev.children && Object.keys(prev.children).length)) {
+            const child = this.digDown(prev)
+            this.assignFocus(child.id)
+          }
         }
+      } else {
+        this.currentFocusNode = undefined;
+        this.currentFocusNodeId = undefined;
+        this.currentFocusNodeIndex = undefined;
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,8 +264,10 @@ export class Lrud {
       const top = this.climbUp(parentNode, '*')
       if (top) {
         const prev = this.getPrevChild(top)
-        const child = this.digDown(prev)
-        this.assignFocus(child.id)
+        if (isNodeFocusable(prev) || (prev && prev.children && Object.keys(prev.children).length)) {
+          const child = this.digDown(prev)
+          this.assignFocus(child.id)
+        }
       }
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,3 +31,7 @@ export interface KeyEvent {
 export interface InsertTreeOptions {
     maintainIndex: boolean;
 }
+
+export interface UnregisterNodeOptions {
+    forceRefocus: boolean;
+}

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -493,4 +493,40 @@ describe('unregisterNode()', () => {
       'root.children.x.children.x-2'
     ])
   })
+
+  test('unregistering a pibling of the focused node', () => {
+    const nav = new Lrud()
+
+    nav.register('root', {
+      orientation: 'horizontal'
+    })
+
+    nav.register('node1', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+
+    nav.register('item1', {
+      parent: 'node1',
+      selectAction: {}
+    })
+
+    nav.register('node2', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+
+    nav.register('item2', {
+      parent: 'node2',
+      selectAction: {}
+    })
+
+    nav.assignFocus('node2')
+
+    expect(nav.currentFocusNodeId).toEqual('item2')
+
+    nav.unregisterNode('item1')
+
+    expect(nav.currentFocusNodeId).toEqual('item2')
+  })
 })

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -529,4 +529,39 @@ describe('unregisterNode()', () => {
 
     expect(nav.currentFocusNodeId).toEqual('item2')
   })
+
+  test('unregistering with forceRefocus false should not do a refocus - removing focused node', () => {
+    const nav = new Lrud()
+
+    nav.register('root')
+      .register('node1', { isFocusable: true })
+      .register('node2', { isFocusable: true })
+      .register('node3', { isFocusable: true })
+
+    nav.assignFocus('node2')
+
+    nav.unregisterNode('node2', { forceRefocus: false })
+
+    expect(nav.currentFocusNodeId).toEqual(undefined)
+    expect(nav.tree.root.activeChild).toEqual(undefined)
+  })
+
+  test('unregistering with forceRefocus false should not do a refocus - removing parent of focused node', () => {
+    const nav = new Lrud()
+
+    nav.register('root')
+      .register('box1')
+      .register('node1', { isFocusable: true, parent: 'box1' })
+      .register('node2', { isFocusable: true, parent: 'box1' })
+      .register('box2')
+      .register('node4', { isFocusable: true, parent: 'box2' })
+      .register('node5', { isFocusable: true, parent: 'box2' })
+
+    nav.assignFocus('node2')
+
+    nav.unregisterNode('box1', { forceRefocus: false })
+
+    expect(nav.currentFocusNodeId).toEqual(undefined)
+    expect(nav.tree.root.activeChild).toEqual(undefined)
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

A new config object is given to `unregisterNode()`. One of these options, `forceRefocus` will make LRUD find a new node to focus on if unregistering the currently focused node.

To match current behaviour, `forceRefocus` defaults to true.

Also fixes an underlying refocus on unregister issue.

## Motivation and Context
Suggested by https://github.com/bbc/lrud/issues/23

Agree in principle - there are simply some scenarios where LRUD will not be able find a good fit to focus on. In this case, the developer should call `assignFocus` after `unregisterNode` in API-land.

## How Has This Been Tested?
New unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
