### PR TITLE
[Fix] Fix onSelect and "select" event emission

### DIFF
--- a/src/events.test.js
+++ b/src/events.test.js
@@ -361,7 +361,7 @@ describe('event scenarios', () => {
 
     navigation.handleKeyEvent({ direction: 'ENTER' })
 
-    expect(onSelectMock.mock.calls.length).toEqual(1)
+    expect(onSelectMock).toBeCalledTimes(1)
   })
 
   test('instance emit select', () => {
@@ -376,7 +376,7 @@ describe('event scenarios', () => {
 
     navigation.handleKeyEvent({ direction: 'ENTER' })
 
-    expect(onSelectMock.mock.calls.length).toEqual(1)
+    expect(onSelectMock).toBeCalledTimes(1)
   })
 
   test('node onSelect & instance emit select', () => {
@@ -391,6 +391,6 @@ describe('event scenarios', () => {
 
     navigation.handleKeyEvent({ direction: 'ENTER' })
 
-    expect(onSelectMock.mock.calls.length).toEqual(2)
+    expect(onSelectMock).toBeCalledTimes(2)
   })
 })

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -349,4 +349,48 @@ describe('event scenarios', () => {
 
     expect(inactiveChild).toEqual('row-a')
   })
+
+  test('node onSelect', () => {
+    const navigation = new Lrud()
+    const onSelectMock = jest.fn()
+
+    navigation.registerNode('root')
+      .registerNode('a', { isFocusable: true, onSelect: onSelectMock })
+
+    navigation.assignFocus('a')
+
+    navigation.handleKeyEvent({ direction: 'ENTER' })
+
+    expect(onSelectMock.mock.calls.length).toEqual(1)
+  })
+
+  test('instance emit select', () => {
+    const navigation = new Lrud()
+    const onSelectMock = jest.fn()
+
+    navigation.registerNode('root')
+      .registerNode('a', { isFocusable: true })
+
+    navigation.assignFocus('a')
+    navigation.on('select', onSelectMock)
+
+    navigation.handleKeyEvent({ direction: 'ENTER' })
+
+    expect(onSelectMock.mock.calls.length).toEqual(1)
+  })
+
+  test('node onSelect & instance emit select', () => {
+    const navigation = new Lrud()
+    const onSelectMock = jest.fn()
+
+    navigation.registerNode('root')
+      .registerNode('a', { isFocusable: true, onSelect: onSelectMock })
+
+    navigation.assignFocus('a')
+    navigation.on('select', onSelectMock)
+
+    navigation.handleKeyEvent({ direction: 'ENTER' })
+
+    expect(onSelectMock.mock.calls.length).toEqual(2)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -624,9 +624,11 @@ export class Lrud {
     const currentFocusNode = this.getNode(this.currentFocusNodeId)
 
     // if all we're doing is processing an enter, just run the `onSelect` function of the current node...
-    if (direction === 'ENTER' && currentFocusNode.onSelect) {
+    if (direction === 'ENTER') {
       this.emitter.emit('select', currentFocusNode);
-      currentFocusNode.onSelect(currentFocusNode)
+      if (currentFocusNode.onSelect) {
+        currentFocusNode.onSelect(currentFocusNode)
+      }
       return
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,6 +15,7 @@ export interface Node {
     onEnter?: Function;
     activeChild?: string;
     children?: any;
+    onSelect?: Function
 }
 
 export interface Override {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

"select" events should be emitted without `onSelect` being required.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #27 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->

New unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
