### PR TITLE
[Fix] Assigning focus, and moving over/to branches without focusable children

### DIFF
--- a/src/focus-on-empty-node.test.js
+++ b/src/focus-on-empty-node.test.js
@@ -105,7 +105,7 @@ describe('Focusing on empty nodes', () => {
     }).toThrow()
   })
 
-  it('should handle a move to an empty branch', () => {
+  it('should handle a move to an empty branch - vertical - dont change the focus', () => {
     const nav = new Lrud()
 
     nav.registerNode('root', {
@@ -130,9 +130,42 @@ describe('Focusing on empty nodes', () => {
     nav.assignFocus('root')
 
     nav.handleKeyEvent({ direction: 'down' })
+
+    expect(nav.currentFocusNodeId).toEqual('item1')
   })
 
-  it('should jump over empty branches when moving', () => {
+  it('should handle a move to an empty branch - vertical - dont change the focus', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', {
+      orientation: 'horizontal'
+    })
+
+    nav.registerNode('node1', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.registerNode('node2', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.register('item1', {
+      parent: 'node1',
+      selectAction: {}
+    })
+
+    nav.assignFocus('root')
+
+    expect(nav.currentFocusNodeId).toEqual('item1')
+
+    nav.handleKeyEvent({ direction: 'right' })
+
+    expect(nav.currentFocusNodeId).toEqual('item1')
+  })
+
+  it('should jump over empty branches when moving - vertical', () => {
     const nav = new Lrud()
 
     nav.registerNode('root', {
@@ -167,5 +200,53 @@ describe('Focusing on empty nodes', () => {
     nav.assignFocus('root')
 
     nav.handleKeyEvent({ direction: 'down' })
+  })
+
+  it('should jump over multiple empty branches - vertical', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav
+      .registerNode('branch1', { orientation: 'horizontal' })
+      .registerNode('item1', { parent: 'branch1', isFocusable: true })
+
+    nav.registerNode('branch2', { orientation: 'horizontal' })
+    nav.registerNode('branch3', { orientation: 'horizontal' })
+
+    nav
+      .registerNode('branch4', { orientation: 'horizontal' })
+      .registerNode('item4', { parent: 'branch4', isFocusable: true })
+
+    nav.assignFocus('root')
+    expect(nav.currentFocusNodeId).toEqual('item1')
+
+    nav.handleKeyEvent({ direction: 'down' })
+
+    expect(nav.currentFocusNodeId).toEqual('item4')
+  })
+
+  it('should jump over multiple empty branches - horizontal', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'horizontal' })
+
+    nav
+      .registerNode('branch1', { orientation: 'horizontal' })
+      .registerNode('item1', { parent: 'branch1', isFocusable: true })
+
+    nav.registerNode('branch2', { orientation: 'horizontal' })
+    nav.registerNode('branch3', { orientation: 'horizontal' })
+
+    nav
+      .registerNode('branch4', { orientation: 'horizontal' })
+      .registerNode('item4', { parent: 'branch4', isFocusable: true })
+
+    nav.assignFocus('root')
+    expect(nav.currentFocusNodeId).toEqual('item1')
+
+    nav.handleKeyEvent({ direction: 'right' })
+
+    expect(nav.currentFocusNodeId).toEqual('item4')
   })
 })

--- a/src/focus-on-empty-node.test.js
+++ b/src/focus-on-empty-node.test.js
@@ -1,0 +1,107 @@
+/* eslint-env jest */
+
+const { Lrud } = require('./index')
+
+describe('Focusing on empty nodes', () => {
+  it('when focusing on branch, should jump to first child with focusable nodes', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav.registerNode('branch1', { orientation: 'horizontal' })
+    nav.registerNode('branch2', { orientation: 'horizontal' })
+
+    nav.register('item', {
+      parent: 'branch2',
+      isFocusable: true
+    })
+
+    nav.assignFocus('root')
+
+    expect(nav.currentFocusNodeId).toEqual('item')
+  })
+
+  it('when focusing on branch, should jump to first child with focusable nodes - multiple empty preceding siblings', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav.registerNode('branch1', { orientation: 'horizontal' })
+    nav.registerNode('branch2', { orientation: 'horizontal' })
+    nav.registerNode('branch3', { orientation: 'horizontal' })
+    nav.registerNode('branch4', { orientation: 'horizontal' })
+
+    nav.register('item', {
+      parent: 'branch4',
+      isFocusable: true
+    })
+
+    nav.assignFocus('root')
+
+    expect(nav.currentFocusNodeId).toEqual('item')
+  })
+
+  it('find focusable node when dead branches first', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav.registerNode('branch1', { orientation: 'horizontal' })
+    nav.registerNode('branch2', { orientation: 'horizontal', parent: 'branch1' })
+    nav.registerNode('branch3', { orientation: 'horizontal', parent: 'branch2' })
+
+    nav.registerNode('branch4', { orientation: 'horizontal' })
+
+    nav.register('item', {
+      parent: 'branch4',
+      isFocusable: true
+    })
+
+    nav.assignFocus('root')
+
+    expect(nav.currentFocusNodeId).toEqual('item')
+  })
+
+  it('find focusable node when multiple dead branches first', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav.registerNode('branch1', { orientation: 'horizontal' })
+    nav.registerNode('branch2', { orientation: 'horizontal', parent: 'branch1' })
+    nav.registerNode('branch3', { orientation: 'horizontal', parent: 'branch2' })
+
+    nav.registerNode('branch4', { orientation: 'horizontal' })
+    nav.registerNode('branch5', { orientation: 'horizontal', parent: 'branch4' })
+    nav.registerNode('branch6', { orientation: 'horizontal', parent: 'branch5' })
+
+    nav.registerNode('branch7', { orientation: 'horizontal' })
+
+    nav.register('item', {
+      parent: 'branch7',
+      isFocusable: true
+    })
+
+    nav.assignFocus('root')
+
+    expect(nav.currentFocusNodeId).toEqual('item')
+  })
+
+  it('if assigning focus on a branch that has no focusable children, throw exception', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', { orientation: 'vertical' })
+
+    nav.registerNode('branch1', { orientation: 'horizontal' })
+    nav.registerNode('branch2', { orientation: 'horizontal', parent: 'branch1' })
+    nav.registerNode('branch3', { orientation: 'horizontal', parent: 'branch2' })
+
+    nav.registerNode('branch4', { orientation: 'horizontal' })
+    nav.registerNode('branch5', { orientation: 'horizontal', parent: 'branch4' })
+    nav.registerNode('branch6', { orientation: 'horizontal', parent: 'branch5' })
+
+    expect(() => {
+      nav.assignFocus('root')
+    }).toThrow()
+  })
+})

--- a/src/focus-on-empty-node.test.js
+++ b/src/focus-on-empty-node.test.js
@@ -104,4 +104,68 @@ describe('Focusing on empty nodes', () => {
       nav.assignFocus('root')
     }).toThrow()
   })
+
+  it('should handle a move to an empty branch', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', {
+      orientation: 'vertical'
+    })
+
+    nav.registerNode('node1', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.registerNode('node2', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.register('item1', {
+      parent: 'node1',
+      selectAction: {}
+    })
+
+    nav.assignFocus('root')
+
+    nav.handleKeyEvent({ direction: 'down' })
+  })
+
+  it('should jump over empty branches when moving', () => {
+    const nav = new Lrud()
+
+    nav.registerNode('root', {
+      orientation: 'vertical'
+    })
+
+    nav.registerNode('node1', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.registerNode('node2', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.registerNode('node3', {
+      orientation: 'horizontal',
+      parent: 'root'
+    })
+
+    nav.register('item1', {
+      parent: 'node1',
+      isFocusable: true
+    })
+
+    nav.register('item3', {
+      parent: 'node3',
+      isFocusable: true
+    })
+
+    nav.assignFocus('root')
+
+    nav.handleKeyEvent({ direction: 'down' })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,6 +496,10 @@ export class Lrud {
       const parentNode = this.getNode(node.parent);
       parentNode.activeChild = node.id
       const nextSiblingFromNode = this.getNextChildInDirection(parentNode, direction);
+      // if the next sibling is ME, we're in an infinite loop - just return null
+      if (nextSiblingFromNode.id === node.id) {
+        return null
+      }
       return this.digDown(nextSiblingFromNode, direction)
     }
 
@@ -517,7 +521,7 @@ export class Lrud {
    * @param {object} node
    * @param {string} direction
    */
-  getNextChildInDirection(node: Node, direction: string = null) {
+  getNextChildInDirection(node: Node, direction: string = null): Node {
     if (!direction) {
       return this.getNextChild(node)
     }
@@ -656,6 +660,10 @@ export class Lrud {
     // ...and depending on if we're able to find a child, dig down from the child or from the original top...
     const focusableNode = (nextChild) ? this.digDown(nextChild, direction) : this.digDown(topNode, direction)
 
+    if (!focusableNode) {
+      return
+    }
+
     // ...give an opportunity for the move to be cancelled by the leaving node
     if (currentFocusNode.shouldCancelLeave) {
       if (currentFocusNode.shouldCancelLeave(currentFocusNode, focusableNode)) {
@@ -768,7 +776,7 @@ export class Lrud {
   assignFocus(nodeId: string) {
     let node = this.getNode(nodeId)
 
-    if (!this.doesNodeHaveFocusableChildren(node)) {
+    if (node.children && !this.doesNodeHaveFocusableChildren(node)) {
       throw new Error(`"${node.id}" does not have focusable children. Are you trying to assign focus to ${node.id}?`)
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,7 +19,12 @@ export interface Node {
     onEnterCancelled?: Function;
     activeChild?: string;
     children?: any;
-    onSelect?: Function
+    onSelect?: Function;
+    onInactive?: Function;
+    onActive?: Function;
+    onActiveChildChange?: Function;
+    onBlur?: Function;
+    onFocus?: Function;
 }
 
 export interface Override {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Ensures 2 things happen

- if assigning focus to a node with children, but 0 focusable children, throw an exception
- if digging down from a node that is not focusable, and has 0 focusable children, instead dig down from its next sibling

This ensures that actions that would result in focus trying to be set on something invalid either don't happen, or can be caught properly.

I've also done minor fixes in place around typescript

- added return type to `getNode()`
- added types to interface for node

## Motivation and Context
Fixes #26 

## How Has This Been Tested?
New unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
