### PR TITLE
isFocusable overrides selectAction presence

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -405,7 +405,7 @@ A: Ensure that the parent nodes, etc. have the correct orientation in order to b
 
 > Q: All my parents have orientations, everything is setup in the navigation tree, and I STILL can't focus on the node I expect.
 
-A: Ensure the node has either `isFocusable: true` or a `selectAction` registered against it. A node needs either one of these in order to be considered "focusable"
+A: Ensure the node has either `isFocusable: true` or a `selectAction` registered against it. A node needs either one of these in order to be considered "focusable". `isFocusable` is prioritised over `selectAction` so a node with `isFocusable: false` will never be focusable.
 
 > Q: What is the different between `onBlur/onFocus` and `onLeave/onEnter`?
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -89,6 +89,15 @@ describe('isNodeFocusable()', () => {
 
     expect(isNodeFocusable(node)).toEqual(false)
   })
+
+  it('node should not be focusable, it has isFocusable false, and a selectAction', () => {
+    const node = {
+      isFocusable: false,
+      selectAction: true
+    }
+
+    expect(isNodeFocusable(node)).toEqual(false)
+  })
 })
 
 describe('isDirectionAndOrientationMatching()', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const Closest = (values, goal) => values.reduce(function (prev, curr) {
  * 
  * @param {object} node
  */
-export const isNodeFocusable = (node) => !!(node.selectAction || node.isFocusable)
+export const isNodeFocusable = (node) => node.isFocusable != null ? node.isFocusable : !!node.selectAction
 
 /**
  * given a keyCode, lookup and return the direction from the keycodes mapping file


### PR DESCRIPTION
## Description
Solidifies the interaction between `selectAction` and `isFocusable` properties on a node to enforce that when a node has `isFocusable: false` it will not be focusable, regardless of the presence of a `selectAction` property.

## Motivation and Context
This change makes it easier to have buttons where the focusability can be changed without having to remove and re-add the `selectAction`.

## How Has This Been Tested?
Added an automated test to the `utils` file to ensure this behaves as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
