### PR TITLE
Add a function to update nodes in place

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,6 +285,15 @@ navigation.overrides = {
 }
 ```
 
+## Tree Node Updates
+
+Nodes in a tree can have their properties updated in place using `navigation.updateNode`.
+
+```js
+navigation.registerNode('root', { isFocusable: true })
+navigation.updateNode('root', { isFocusable: false, isIndexAlign: true })
+```
+
 # Tree and Partial Tree Insertion & Registering
 
 LRUD supports the ability to register an entire tree at once.

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export class Lrud {
     }
 
     // if no `index` set, calculate it
-    if (!node.index) {
+    if (!(node.index != null)) {
       const parentNode = this.getNode(node.parent)
       if (parentNode) {
         const parentsChildren = this.getNode(node.parent).children
@@ -888,5 +888,35 @@ export class Lrud {
 
   doesNodeHaveFocusableChildren(node: Node) : boolean {
     return this.focusableNodePathList.some(p => p.includes(`${node.id}.`))
+  }
+
+  /**
+   * Update the properties of a node in place
+   * @param {string} nodeId
+   * @param {object} update
+   */
+  updateNode(nodeId: string, update: Node) {
+    const node = this.getNode(nodeId)
+    if (!node) return
+
+    const parentNode = this.getNode(node.parent)
+    let subsequentChildren = []
+    const originalNodeIndex = node.index
+    if (parentNode) {
+      subsequentChildren = Object.keys(parentNode.children).map(x => parentNode.children[x]).filter(x => x.index > node.index)
+    }
+    this.unregisterNode(node.id, {forceRefocus: update.isFocusable === false})
+
+    for (let key in update) {
+      node[key] = update[key]
+    }
+
+    for (let child of subsequentChildren) {
+      const childNode = this.getNode(child.id)
+      childNode.index += 1
+    }
+
+    this.registerTree({ [node.id]: node })
+
   }
 }

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -458,4 +458,96 @@ describe('lrud', () => {
       expect(navigation.getNode('d').index).toEqual(3)
     })
   })
+
+  describe('updateNode', () => {
+    test('updating a property should change the property on the node', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('a', { isFocusable: true })
+
+      navigation.updateNode('a', { isFocusable: false, isIndexAlign: true })
+
+      expect(navigation.getNode('a').isFocusable).toEqual(false)
+      expect(navigation.getNode('a').isIndexAlign).toEqual(true)
+    })
+
+    test('making a previously focusable node unfocusable should remove it from the list of focusable nodes', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('a', { isFocusable: true })
+
+      navigation.updateNode('a', { isFocusable: false })
+
+      expect(navigation.focusableNodePathList).not.toEqual(expect.arrayContaining(['root.children.a']))
+    })
+
+    test('current focus should not be updated when updating a node', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('a', { isFocusable: true })
+        .registerNode('b', { isFocusable: true })
+
+      navigation.assignFocus('b')
+      navigation.updateNode('a', { isFocusable: false })
+
+      expect(navigation.currentFocusNodeId).toEqual('b')
+    })
+
+    test('node indexes should not change unless specified', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('a', { isFocusable: true, orientation: 'horizontal' })
+        .registerNode('b', { isFocusable: true, parent: 'a' })
+        .registerNode('c', { isFocusable: true, parent: 'a' })
+
+      navigation.assignFocus('c')
+      navigation.updateNode('b', { isFocusable: false })
+
+      expect(navigation.getNode('c').index).toEqual(1)
+      expect(navigation.getNode('b').index).toEqual(0)
+    })
+
+    test('children of a node should remain unaltered if id is not changed', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('a', { isFocusable: true, orientation: 'horizontal' })
+        .registerNode('b', { isFocusable: true, parent: 'a' })
+        .registerNode('c', { isFocusable: true, parent: 'a' })
+
+      navigation.assignFocus('c')
+      navigation.updateNode('a', { isFocusable: false })
+
+      expect(navigation.getNode('c').index).toEqual(1)
+      expect(navigation.getNode('c').parent).toEqual('a')
+      expect(navigation.getNode('c').isFocusable).toEqual(true)
+      expect(navigation.currentFocusNodeId).toEqual('c')
+    })
+
+    test('should recalculate node focus if currentNode is set to be unfocusable', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root', { orientation: 'vertical' }) // Orientation must be set on root or the focus recalculation fails
+        .registerNode('a', { isFocusable: true, orientation: 'horizontal' })
+        .registerNode('b', { isFocusable: true, parent: 'a' })
+        .registerNode('c', { isFocusable: true, parent: 'a' })
+        .registerNode('d', { isFocusable: true, parent: 'root' })
+
+      navigation.assignFocus('c')
+
+      navigation.updateNode('c', { isFocusable: false })
+      expect(navigation.currentFocusNodeId).not.toBeUndefined()
+      expect(navigation.currentFocusNodeId).not.toEqual('c')
+    })
+  })
 })


### PR DESCRIPTION
## Description
Adds an `updateNode` function to allow modification of node properties in place.
This is an initial implementation to get the API change demonstrated, could probably be done more efficiently than this.
Maybe there's some discussion to be had on whether that's something we should be introducing or whether LRUD trees should be expected to be mutatable once they're built.
Should this prevent users manually setting more complicated properties like the index and children?

## Motivation and Context
Need a way of updating the tree to allow changes in state, IE: a button that was previously disabled becoming enabled. Could do this by completely regenerating the tree and replacing in place but that loses any changes to the state of the tree and the active focus states.

## How Has This Been Tested?
Added automated tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
