### PR TITLE
Added feature to change focusability of a node

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,6 +285,15 @@ navigation.overrides = {
 }
 ```
 
+## Modifying Node Focusability
+
+Ability of a node to be focused can be modified using  `navigation.setNodeFocusable`
+
+```js
+navigation.registerNode('root', { isFocusable: true })
+navigation.setNodeFocusable('root', false)
+```
+
 # Tree and Partial Tree Insertion & Registering
 
 LRUD supports the ability to register an entire tree at once.

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,14 +265,7 @@ export class Lrud {
       delete parentNode.activeChild
 
       if (unregisterOptions.forceRefocus) {
-        const top = this.climbUp(parentNode, '*')
-        if (top) {
-          const prev = this.getPrevChild(top)
-          if (isNodeFocusable(prev) || (prev && prev.children && Object.keys(prev.children).length)) {
-            const child = this.digDown(prev)
-            this.assignFocus(child.id)
-          }
-        }
+        this.recalculateFocus(nodeClone)
       } else {
         this.currentFocusNode = undefined;
         this.currentFocusNodeId = undefined;
@@ -827,6 +820,28 @@ export class Lrud {
   }
 
   /**
+   * If the focus of the tree is out of sync, ie, the current focused node becomes unfocusable this can be used to fall back to another focus.
+   * @param {focusedNode}
+   */
+  recalculateFocus(node: Node) {
+    const parentNode = this.getNode(node.parent)
+    const top = this.climbUp(parentNode, '*')
+    if (top) {
+      const prev = this.getPrevChild(top)
+      if (isNodeFocusable(prev) || (prev && prev.children && Object.keys(prev.children).length)) {
+        const child = this.digDown(prev)
+        this.assignFocus(child.id)
+      } else {
+        this.assignFocus(top.id)
+      }
+    } else {
+        this.currentFocusNode = undefined;
+        this.currentFocusNodeId = undefined;
+        this.currentFocusNodeIndex = undefined;
+    }
+  }
+
+  /**
    * given a tree, return an array of Nodes in that tree
    * 
    * @param {object} tree 
@@ -888,5 +903,40 @@ export class Lrud {
 
   doesNodeHaveFocusableChildren(node: Node) : boolean {
     return this.focusableNodePathList.some(p => p.includes(`${node.id}.`))
+  }
+
+  /**
+   * Change the ability of a node to be focused in place
+   * @param {string} nodeId
+   * @param {boolean} isFocusable
+   */
+  setNodeFocusable(nodeId: string, isFocusable: boolean) {
+    const node = this.getNode(nodeId)
+    if (!node) return
+
+    const nodeIsFocusable = isNodeFocusable(node)
+    if (nodeIsFocusable === isFocusable) return
+
+    node.isFocusable = isFocusable
+    if (!isFocusable) {
+      const path = this.getPathForNodeId(nodeId)
+      this.focusableNodePathList.splice(this.focusableNodePathList.indexOf(path), 1)
+      const parent = this.getNode(node.parent)
+      if (parent && parent.activeChild && parent.activeChild === nodeId) {
+        delete parent.activeChild
+        // Reset activeChild
+        const nextChild = this.getNextChild(parent)
+        if (nextChild) {
+          this.setActiveChild(parent.id, nextChild.id)
+        }
+      }
+
+      if (this.currentFocusNodeId === nodeId) {
+        this.recalculateFocus(node)
+      }
+    } else {
+      const path = this.getPathForNodeId(nodeId)
+      this.focusableNodePathList.push(path)
+    }
   }
 }


### PR DESCRIPTION
## Description
Adds an `setNodeFocusable` function to change the isFocusable state of a node.
Also moves the functionality for recalculating focus from `unregisterNode` into a shared function so the same process can be used for unfocusing and removing a node.

## Motivation and Context
Need a way of updating the tree to allow changes in state, IE: a button that was previously disabled becoming enabled. Could do this by completely regenerating the tree and replacing in place but that loses any changes to the state of the tree and the active focus states.
Split from larger PR due to feedback: https://github.com/bbc/lrud/pull/38#issuecomment-547454172

## How Has This Been Tested?
Added automated tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
