### PR TITLE
Fixed bug with moving to a row containing unfocusable items

### DIFF
--- a/src/index-align.test.js
+++ b/src/index-align.test.js
@@ -45,6 +45,22 @@ describe('handleKeyEvent() - simple index alignment behaviour', () => {
 
     expect(navigation.currentFocusNodeId).toEqual('e')
   })
+
+  test('moving between 2 rows when matching index aligned node is unfocusable', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { orientation: 'vertical', isIndexAlign: true })
+    navigation.registerNode('a', { parent: 'root', orientation: 'horizontal' })
+    navigation.registerNode('a0', { parent: 'a', isFocusable: true })
+    navigation.registerNode('a1', { parent: 'a', isFocusable: true })
+    navigation.registerNode('b', { parent: 'root', orientation: 'horizontal' })
+    navigation.registerNode('b0', { parent: 'b', isFocusable: false })
+    navigation.registerNode('b1', { parent: 'b', isFocusable: true })
+
+    navigation.assignFocus('a0')
+    navigation.handleKeyEvent({direction: 'down'})
+    expect(navigation.currentFocusNodeId).toEqual('b1')
+  })
 })
 
 describe('handleKeyEvent() - index ranges', () => {

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -587,20 +587,4 @@ describe('lrud', () => {
       expect(navigation.getNode('a').activeChild).toEqual('c')
     })
   })
-
-  describe('regression test', () => {
-    test('going down a row when matching index aligned node is unfocusable', () => {
-      const navigation = new Lrud()
-      navigation.registerNode('root', { orientation: 'vertical', isIndexAlign: true })
-      navigation.registerNode('a', { parent: 'root', orientation: 'horizontal' })
-      navigation.registerNode('a0', { parent: 'a', isFocusable: true })
-      navigation.registerNode('a1', { parent: 'a', isFocusable: true })
-      navigation.registerNode('b', { parent: 'root', orientation: 'horizontal' })
-      navigation.registerNode('b0', { parent: 'b', isFocusable: false })
-      navigation.registerNode('b1', { parent: 'b', isFocusable: true })
-
-      navigation.assignFocus('a0')
-      expect(() => navigation.handleKeyEvent({direction: 'DOWN'})).not.toThrow()
-    })
-  })
 })

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -587,4 +587,20 @@ describe('lrud', () => {
       expect(navigation.getNode('a').activeChild).toEqual('c')
     })
   })
+
+  describe('regression test', () => {
+    test('going down a row when matching index aligned node is unfocusable', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root', { orientation: 'vertical', isIndexAlign: true })
+      navigation.registerNode('a', { parent: 'root', orientation: 'horizontal' })
+      navigation.registerNode('a0', { parent: 'a', isFocusable: true })
+      navigation.registerNode('a1', { parent: 'a', isFocusable: true })
+      navigation.registerNode('b', { parent: 'root', orientation: 'horizontal' })
+      navigation.registerNode('b0', { parent: 'b', isFocusable: false })
+      navigation.registerNode('b1', { parent: 'b', isFocusable: true })
+
+      navigation.assignFocus('a0')
+      expect(() => navigation.handleKeyEvent({direction: 'DOWN'})).not.toThrow()
+    })
+  })
 })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -264,15 +264,18 @@ describe('_findChildWithClosestIndex()', () => {
       children: {
         a: {
           id: 'a',
-          index: 0
+          index: 0,
+          isFocusable: true
         },
         b: {
           id: 'b',
-          index: 1
+          index: 1,
+          isFocusable: true
         },
         c: {
           id: 'c',
-          index: 2
+          index: 2,
+          isFocusable: true
         }
       }
     }
@@ -288,15 +291,18 @@ describe('_findChildWithClosestIndex()', () => {
       children: {
         a: {
           id: 'a',
-          index: 0
+          index: 0,
+          isFocusable: true
         },
         b: {
           id: 'b',
-          index: 1
+          index: 1,
+          isFocusable: true
         },
         c: {
           id: 'c',
-          index: 2
+          index: 2,
+          isFocusable: true
         }
       }
     }
@@ -312,15 +318,18 @@ describe('_findChildWithClosestIndex()', () => {
       children: {
         a: {
           id: 'a',
-          index: 0
+          index: 0,
+          isFocusable: true
         },
         b: {
           id: 'b',
-          index: 5
+          index: 5,
+          isFocusable: true
         },
         c: {
           id: 'c',
-          index: 10
+          index: 10,
+          isFocusable: true
         }
       }
     }
@@ -365,19 +374,23 @@ describe('_findChildWithClosestIndex()', () => {
       children: {
         a: {
           id: 'a',
-          index: 0
+          index: 0,
+          isFocusable: true
         },
         b: {
           id: 'b',
-          index: 1
+          index: 1,
+          isFocusable: true
         },
         c: {
           id: 'c',
-          index: 2
+          index: 2,
+          isFocusable: true
         },
         d: {
           id: 'd',
-          index: 5
+          index: 5,
+          isFocusable: true
         }
       }
     }
@@ -395,6 +408,67 @@ describe('_findChildWithClosestIndex()', () => {
     const found = _findChildWithClosestIndex(node, 1)
 
     expect(found).toEqual(null)
+  })
+
+  it('should return null if no focusable child', () => {
+    const node = {
+      id: 'root',
+      isFocusable: true,
+      activeChild: 'a',
+      children: {
+        a: {
+          id: 'a',
+          index: 0
+        },
+        b: {
+          id: 'b',
+          index: 1
+        },
+        c: {
+          id: 'c',
+          index: 2
+        },
+        d: {
+          id: 'd',
+          index: 5
+        }
+      }
+    }
+
+    const found = _findChildWithClosestIndex(node, 1)
+
+    expect(found).toEqual(null)
+  })
+
+  it('should return closest focusable child', () => {
+    const node = {
+      id: 'root',
+      isFocusable: true,
+      activeChild: 'a',
+      children: {
+        a: {
+          id: 'a',
+          index: 0
+        },
+        b: {
+          id: 'b',
+          index: 1
+        },
+        c: {
+          id: 'c',
+          index: 2
+        },
+        d: {
+          id: 'd',
+          index: 5,
+          isFocusable: true
+        }
+      }
+    }
+
+    const found = _findChildWithClosestIndex(node, 1)
+
+    expect(found).toEqual(node.children.d)
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,7 +127,13 @@ export const _findChildWithClosestIndex = (node, index, indexRange = null) => {
         return activeChild
     }
 
-    const indexes = Object.keys(node.children).map(childId => node.children[childId].index)
+    const indexes = Object.keys(node.children)
+      .filter(childId => isNodeFocusable(node.children[childId]) || node.children[childId].children)
+      .map(childId => node.children[childId].index)
+
+    if (indexes.length <= 0) {
+      return null
+    }
     return _findChildWithIndex(node, Closest(indexes, index))
 }
 


### PR DESCRIPTION
Fixed a bug where moving to a row where the equivalent index is unfocusable would throw an error

## Description
Example of bug
```
[] indicates focus
() indicates unfocusableness

[a] b c d
(e) f g h

Press down

expected result:

 a   b  c d
(e) [f] g h

actual result

[a] b c d
(e) f g h
(Plus a type error)
```

## How Has This Been Tested?
Wrote automated tests, then manually tested on a layout.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
