### PR TITLE
Fixed bug where `digDown` sets a unfocusable node to be a parent's activeChild

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -487,7 +487,6 @@ export class Lrud {
 
     if (!isNodeFocusable(node) && !this.doesNodeHaveFocusableChildren(node)) {
       const parentNode = this.getNode(node.parent);
-      //parentNode.activeChild = node.id
       const nextSiblingFromNode = this.getNextChildInDirection({ ...parentNode, activeChild: node.id }, direction);
       // if the next sibling is ME, we're in an infinite loop - just return null
       if (nextSiblingFromNode.id === node.id) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,8 +494,8 @@ export class Lrud {
 
     if (!isNodeFocusable(node) && !this.doesNodeHaveFocusableChildren(node)) {
       const parentNode = this.getNode(node.parent);
-      parentNode.activeChild = node.id
-      const nextSiblingFromNode = this.getNextChildInDirection(parentNode, direction);
+      //parentNode.activeChild = node.id
+      const nextSiblingFromNode = this.getNextChildInDirection({ ...parentNode, activeChild: node.id }, direction);
       // if the next sibling is ME, we're in an infinite loop - just return null
       if (nextSiblingFromNode.id === node.id) {
         return null

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -458,4 +458,20 @@ describe('lrud', () => {
       expect(navigation.getNode('d').index).toEqual(3)
     })
   })
+
+  describe('digDown', () => {
+    it('does not set an activeChild to an unfocusable element', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('parent', { orientation: 'vertical' })
+        .registerNode('a', { parent: 'parent' })
+        .registerNode('b', { parent: 'parent', isFocusable: true })
+
+      navigation.assignFocus('b')
+      navigation.handleKeyEvent({ direction: 'UP' })
+      expect(navigation.currentFocusNodeId).toEqual('b')
+      expect(navigation.getNode('parent').activeChild).toEqual('b')
+    })
+  })
 })


### PR DESCRIPTION
## Description
Altered method used by digDown to get its next child by not mutating the parent.
Previously this meant that you could end up "half-focusing" a non-focusable element.


## Motivation and Context
Fixes: https://github.com/bbc/lrud/issues/41

## How Has This Been Tested?
Automated testing + manual testing
## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
