### PR TITLE
[issue 34] Fix call of the method sort with array of numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,7 @@ export class Lrud {
 
     const children = Object.keys(node.children).map(childId => node.children[childId])
 
-    children.sort(function (a, b) {
-      return a.index - b.index
-    })
+    children.sort((a, b)  =>  a.index - b.index)
 
     node.children = {}
 
@@ -597,7 +595,7 @@ export class Lrud {
       return undefined
     }
 
-    const orderedIndexes = Object.keys(node.children).map(childId => node.children[childId].index).sort()
+    const orderedIndexes = Object.keys(node.children).map(childId => node.children[childId].index).sort((a, b)  =>  a - b)
 
     return _findChildWithIndex(node, orderedIndexes[0])
   }
@@ -612,7 +610,7 @@ export class Lrud {
       return undefined
     }
 
-    const orderedIndexes = Object.keys(node.children).map(childId => node.children[childId].index).sort()
+    const orderedIndexes = Object.keys(node.children).map(childId => node.children[childId].index).sort((a, b)  =>  a - b)
 
     return _findChildWithIndex(node, orderedIndexes[orderedIndexes.length - 1])
   }

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -364,17 +364,47 @@ describe('lrud', () => {
   })
 
   describe('getNodeFirstChild()', () => {
+    test('should return undefined - node with no children', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('b')
+
+      const node = navigation.getNode('b')
+
+      expect(navigation.getNodeFirstChild(node)).toBeUndefined()
+    })
+
     test('should return child with index of 1 - added without indexes', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a')
       navigation.registerNode('b')
+      navigation.registerNode('a')
       navigation.registerNode('c')
 
       const root = navigation.getNode('root')
 
-      expect(navigation.getNodeFirstChild(root).id).toEqual('a')
+      expect(navigation.getNodeFirstChild(root).id).toEqual('b')
+    })
+
+    test('should return child with index of 1 - added without indexes, more than 9 nodes', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('b')
+      navigation.registerNode('a')
+      navigation.registerNode('h')
+      navigation.registerNode('g')
+      navigation.registerNode('f')
+      navigation.registerNode('i')
+      navigation.registerNode('d')
+      navigation.registerNode('j')
+      navigation.registerNode('k')
+
+      const root = navigation.getNode('root')
+
+      expect(navigation.getNodeFirstChild(root).id).toEqual('b')
     })
 
     test('should return child with index of 1 - added out of order, with indexes', () => {
@@ -388,6 +418,27 @@ describe('lrud', () => {
       const root = navigation.getNode('root')
 
       expect(navigation.getNodeFirstChild(root).id).toEqual('b')
+    })
+
+    test('should return child with index of 1 - added out of order, with indexes, more than 9 nodes', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('a', { index: 21 })
+      navigation.registerNode('b', { index: 10 })
+      navigation.registerNode('c', { index: 3 })
+      navigation.registerNode('d', { index: 5 })
+      navigation.registerNode('e', { index: 4 })
+      navigation.registerNode('f', { index: 7 })
+      navigation.registerNode('g', { index: 6 })
+      navigation.registerNode('h', { index: 9 })
+      navigation.registerNode('i', { index: 8 })
+      navigation.registerNode('j', { index: 15 })
+      navigation.registerNode('k', { index: 11 })
+
+      const root = navigation.getNode('root')
+
+      expect(navigation.getNodeFirstChild(root).id).toEqual('c')
     })
   })
 
@@ -405,6 +456,26 @@ describe('lrud', () => {
       expect(navigation.getNodeLastChild(root).id).toEqual('c')
     })
 
+    test('should return child with last index - more than 9 elements', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('1')
+      navigation.registerNode('2')
+      navigation.registerNode('3')
+      navigation.registerNode('4')
+      navigation.registerNode('5')
+      navigation.registerNode('6')
+      navigation.registerNode('7')
+      navigation.registerNode('8')
+      navigation.registerNode('9')
+      navigation.registerNode('10')
+
+      const root = navigation.getNode('root')
+
+      expect(navigation.getNodeLastChild(root).id).toEqual('10')
+    })
+
     test('should return child with last index - added with indexes, out of order', () => {
       const navigation = new Lrud()
 
@@ -416,6 +487,27 @@ describe('lrud', () => {
       const root = navigation.getNode('root')
 
       expect(navigation.getNodeLastChild(root).id).toEqual('a')
+    })
+
+    test('should return child with last index - added with indexes, out of order, more than 9', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('a', { index: 3 })
+      navigation.registerNode('b', { index: 1 })
+      navigation.registerNode('c', { index: 2 })
+      navigation.registerNode('d', { index: 5 })
+      navigation.registerNode('e', { index: 8 })
+      navigation.registerNode('f', { index: 7 })
+      navigation.registerNode('g', { index: 3 })
+      navigation.registerNode('h', { index: 6 })
+      navigation.registerNode('i', { index: 9 })
+      navigation.registerNode('j', { index: 10 })
+      navigation.registerNode('k', { index: 11 })
+
+      const root = navigation.getNode('root')
+
+      expect(navigation.getNodeLastChild(root).id).toEqual('k')
     })
   })
 
@@ -456,6 +548,33 @@ describe('lrud', () => {
       expect(navigation.getNode('b').index).toEqual(1)
       expect(navigation.getNode('c').index).toEqual(2)
       expect(navigation.getNode('d').index).toEqual(3)
+    })
+
+    test('test it through unregister, more than 9 nodes', () => {
+      const navigation = new Lrud()
+
+      navigation
+        .registerNode('root')
+        .registerNode('c', { index: 9 })
+        .registerNode('a', { index: 4 })
+        .registerNode('e', { index: 16 })
+        .registerNode('d', { index: 13 })
+        .registerNode('b', { index: 6 })
+        .registerNode('f', { index: 10 })
+        .registerNode('g', { index: 20 })
+        .registerNode('h', { index: 17 })
+        .registerNode('i', { index: 15 })
+        .registerNode('j', { index: 3 })
+        .registerNode('k', { index: 1 })
+
+      navigation.unregisterNode('e')
+
+      expect(navigation.getNode('k').index).toEqual(0)
+      expect(navigation.getNode('j').index).toEqual(1)
+      expect(navigation.getNode('a').index).toEqual(2)
+      expect(navigation.getNode('b').index).toEqual(3)
+      expect(navigation.getNode('c').index).toEqual(4)
+      expect(navigation.getNode('f').index).toEqual(5)
     })
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the sorting  for the methods `getNodeFirstChild` and `getNodeLastChild`
Fixes #34 
## Description
<!--- Describe your changes in detail -->
- added callback for the call of the sort for the methods `getNodeFirstChild` and `getNodeLastChild`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We use the function `sort` with the methods `reindexChildrenOfNode`, `getNodeFirstChild` and `getNodeLastChild` to sort based on a numeric index.

Currently the sort for `getNodeFirstChild` and `getNodeLastChild` is used without a proper callback, making the sort to be based on string and not numbers causing a wrong sorting.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
unit tests

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
