### PR TITLE
Replace es6 string functions with es5 equivalents

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,13 +61,14 @@ export const isDirectionAndOrientationMatching = (orientation, direction) => {
  * @param {*} node
  */
 export const isNodeInPath = (path, node) => {
-    if (path.startsWith(node.id + '.')) {
+    if (path.lastIndexOf(node.id + '.', 0) === 0) {
         return true
     }
-    if (path.endsWith('.' + node.id)) {
+    var suffix = '.' + node.id
+    if (path.indexOf(suffix, path.length - suffix.length) !== -1) {
         return true
     }
-    if (path.includes('.' + node.id + '.')) {
+    if (path.indexOf('.' + node.id + '.') !== -1) {
         return true
     }
 


### PR DESCRIPTION
## Description
Replace ES6 string functions with ES5 equivalent methods.

## Motivation and Context
We target ES5 with LRUD's build but do not include any string polyfills so we're outputting invalid ES5

## How Has This Been Tested?
Automated tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
