### PR TITLE
Replace uses of ES6 functions with ES5.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   _findChildWithClosestIndex,
   _findChildWithIndex,
   getNodesFromTree,
-  endsWith
+  endsWith,
+  arrayFind
 } from './utils'
 
 import mitt from 'mitt'
@@ -108,7 +109,7 @@ export class Lrud {
     if (nodeId === this.rootNodeId) {
       return this.rootNodeId
     }
-    return this.nodePathList.find(path => endsWith(path, '.' + nodeId))
+    return arrayFind(this.nodePathList, path => endsWith(path, '.' + nodeId))
   }
 
   /**
@@ -154,7 +155,7 @@ export class Lrud {
     // to it so that the parent always has an `activeChild` value
     // we can tell if its parent has any children by checking the nodePathList for
     // entries containing '<parent>.children'
-    const parentsChildPaths = this.nodePathList.find(path => path.indexOf(node.parent + '.children') > -1)
+    const parentsChildPaths = arrayFind(this.nodePathList, path => path.indexOf(node.parent + '.children') > -1)
     if (parentsChildPaths == null) {
       const parentPath = this.getPathForNodeId(node.parent)
       Set(this.tree, parentPath + '.activeChild', nodeId)
@@ -175,7 +176,7 @@ export class Lrud {
 
     // add the node into the tree
     // path is the node's parent plus 'children' plus itself
-    let path = this.nodePathList.find(path => endsWith(path, node.parent)) + '.children.' + nodeId
+    let path = arrayFind(this.nodePathList, path => endsWith(path, node.parent)) + '.children.' + nodeId
     Set(this.tree, path, node)
     this.nodePathList.push(path)
 
@@ -377,7 +378,7 @@ export class Lrud {
     }
 
     // if we have a matching override at this point in the climb, return that target node
-    const matchingOverrideId = Object.keys(this.overrides).find(overrideId => {
+    const matchingOverrideId = arrayFind(Object.keys(this.overrides), overrideId => {
       const override = this.overrides[overrideId]
       return override.id === node.id && override.direction.toUpperCase() === direction.toUpperCase()
     })
@@ -910,7 +911,7 @@ export class Lrud {
   }
 
   doesNodeHaveFocusableChildren(node: Node) : boolean {
-    return this.focusableNodePathList.some(p => p.includes(`${node.id}.`))
+    return this.focusableNodePathList.some(p => p.indexOf(`${node.id}.`) > -1)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
   _findChildWithMatchingIndexRange,
   _findChildWithClosestIndex,
   _findChildWithIndex,
-  getNodesFromTree
+  getNodesFromTree,
+  endsWith
 } from './utils'
 
 import mitt from 'mitt'
@@ -107,7 +108,7 @@ export class Lrud {
     if (nodeId === this.rootNodeId) {
       return this.rootNodeId
     }
-    return this.nodePathList.find(path => path.endsWith('.' + nodeId))
+    return this.nodePathList.find(path => endsWith(path, '.' + nodeId))
   }
 
   /**
@@ -153,7 +154,7 @@ export class Lrud {
     // to it so that the parent always has an `activeChild` value
     // we can tell if its parent has any children by checking the nodePathList for
     // entries containing '<parent>.children'
-    const parentsChildPaths = this.nodePathList.find(path => path.includes(node.parent + '.children'))
+    const parentsChildPaths = this.nodePathList.find(path => path.indexOf(node.parent + '.children') > -1)
     if (parentsChildPaths == null) {
       const parentPath = this.getPathForNodeId(node.parent)
       Set(this.tree, parentPath + '.activeChild', nodeId)
@@ -174,7 +175,7 @@ export class Lrud {
 
     // add the node into the tree
     // path is the node's parent plus 'children' plus itself
-    let path = this.nodePathList.find(path => path.endsWith(node.parent)) + '.children.' + nodeId
+    let path = this.nodePathList.find(path => endsWith(path, node.parent)) + '.children.' + nodeId
     Set(this.tree, path, node)
     this.nodePathList.push(path)
 
@@ -245,10 +246,10 @@ export class Lrud {
 
     // ...remove all its children from both path lists
     this.nodePathList = this.nodePathList.filter(nodeIdPath => {
-      return !nodeIdPath.includes(path + '.children.')
+      return nodeIdPath.indexOf(path + '.children.') === -1
     })
     this.focusableNodePathList = this.focusableNodePathList.filter(nodeIdPath => {
-      return !nodeIdPath.includes(path + '.children.')
+      return nodeIdPath.indexOf(path + '.children.') === -1
     })
 
     // if the node is focusable, remove it from the focusable node path list

--- a/src/index.ts
+++ b/src/index.ts
@@ -912,7 +912,7 @@ export class Lrud {
     }
   }
 
-  doesNodeHaveFocusableChildren(node: Node) : boolean {
+  doesNodeHaveFocusableChildren (node: Node): boolean {
     return this.focusableNodePathList.some(p => p.indexOf(`${node.id}.`) > -1)
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,21 @@ export const Closest = (values, goal) => values.reduce(function (prev, curr) {
 export const endsWith = (str, suffix) => str.indexOf(suffix, str.length - suffix.length) !== -1
 
 /**
+ * Array.prototype.find helper
+ */
+export const arrayFind = (arr, func) => {
+  const len = arr.length
+  let i = 0
+  while(i < len) {
+    if (func(arr[i], i, arr)) {
+      return arr[i]
+    }
+    i++
+  }
+  return undefined
+}
+
+/**
  * check if a given node is focusable
  * 
  * @param {object} node
@@ -101,7 +116,7 @@ export const _findChildWithMatchingIndexRange = (node, index) => {
         return null
     }
 
-    const childWithIndexRangeSpanningIndex = Object.keys(node.children).find(childId => {
+    const childWithIndexRangeSpanningIndex = arrayFind(Object.keys(node.children), childId => {
         const child = node.children[childId]
         return child.indexRange && (child.indexRange[0] <= index && child.indexRange[1] >= index)
     })
@@ -153,7 +168,7 @@ export const _findChildWithIndex = (node, index) => {
         return null
     }
 
-    const childIdWithMatchingIndex = Object.keys(node.children).find(childId => {
+    const childIdWithMatchingIndex = arrayFind(Object.keys(node.children), childId => {
         const childNode = node.children[childId]
         return childNode.index === index
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,15 +14,15 @@ export const Closest = (values: [number], goal: number): number => values.reduce
 /**
  * String.endsWith helper
  */
-export const endsWith = (str, suffix) => str.indexOf(suffix, str.length - suffix.length) !== -1
+export const endsWith = (str, suffix): boolean => str.indexOf(suffix, str.length - suffix.length) !== -1
 
 /**
  * Array.prototype.find helper
  */
-export const arrayFind = (arr, func) => {
+export const arrayFind = <A>(arr: A[], func): A | undefined => {
   const len = arr.length
   let i = 0
-  while(i < len) {
+  while (i < len) {
     if (func(arr[i], i, arr)) {
       return arr[i]
     }
@@ -81,17 +81,17 @@ export const isDirectionAndOrientationMatching = (orientation, direction): boole
  * @param {*} node
  */
 export const isNodeInPath = (path, node): boolean => {
-    if (path.lastIndexOf(node.id + '.', 0) === 0) {
-        return true
-    }
-    if (endsWith(path, '.' + node.id)) {
-        return true
-    }
-    if (path.indexOf('.' + node.id + '.') !== -1) {
-        return true
-    }
+  if (path.lastIndexOf(node.id + '.', 0) === 0) {
+    return true
+  }
+  if (endsWith(path, '.' + node.id)) {
+    return true
+  }
+  if (path.indexOf('.' + node.id + '.') !== -1) {
+    return true
+  }
 
-    return false
+  return false
 }
 
 /**
@@ -112,14 +112,14 @@ export const isNodeInPaths = (paths, node): boolean => {
  * @param {number} index
  */
 export const _findChildWithMatchingIndexRange = (node, index): Node => {
-    if (!node.children) {
-        return null
-    }
+  if (!node.children) {
+    return null
+  }
 
-    const childWithIndexRangeSpanningIndex = arrayFind(Object.keys(node.children), childId => {
-        const child = node.children[childId]
-        return child.indexRange && (child.indexRange[0] <= index && child.indexRange[1] >= index)
-    })
+  const childWithIndexRangeSpanningIndex = arrayFind(Object.keys(node.children), childId => {
+    const child = node.children[childId]
+    return child.indexRange && (child.indexRange[0] <= index && child.indexRange[1] >= index)
+  })
 
   if (childWithIndexRangeSpanningIndex) {
     return node.children[childWithIndexRangeSpanningIndex]
@@ -137,10 +137,10 @@ export const _findChildWithIndex = (node, index): Node => {
     return null
   }
 
-    const childIdWithMatchingIndex = arrayFind(Object.keys(node.children), childId => {
-        const childNode = node.children[childId]
-        return childNode.index === index
-    })
+  const childIdWithMatchingIndex = arrayFind(Object.keys(node.children), childId => {
+    const childNode = node.children[childId]
+    return childNode.index === index
+  })
 
   if (childIdWithMatchingIndex) {
     return node.children[childIdWithMatchingIndex]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,11 @@ export const Closest = (values, goal) => values.reduce(function (prev, curr) {
 })
 
 /**
+ * String.endsWith helper
+ */
+export const endsWith = (str, suffix) => str.indexOf(suffix, str.length - suffix.length) !== -1
+
+/**
  * check if a given node is focusable
  * 
  * @param {object} node
@@ -64,8 +69,7 @@ export const isNodeInPath = (path, node) => {
     if (path.lastIndexOf(node.id + '.', 0) === 0) {
         return true
     }
-    var suffix = '.' + node.id
-    if (path.indexOf(suffix, path.length - suffix.length) !== -1) {
+    if (endsWith(path, '.' + node.id)) {
         return true
     }
     if (path.indexOf('.' + node.id + '.') !== -1) {


### PR DESCRIPTION
## Description
Replaces String.prototype.includes,endswith and Array.prototype.find.

## Motivation and Context
We deploy to ES5 devices but this code does not get polyfilled or transpiled.

## How Has This Been Tested?
Automated testing.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
