### PR TITLE
Make headings 2 and 4 display correctly

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -32,7 +32,7 @@ navigation
   .registerNode('Delete', { parent: 'row-3', indexRange: [4, 6], isFocusable: true })   // these buttons are wider, so are given index ranges
 ```
 
-## Recipe 2 - A series of wrapping rows
+## Recipe 2 - A series of wrapping rows
 
 Representing multiple horizontal rows of content that a user could be browsing, where navigating past the end of a row should return the user focus to the start of that row. _But_, the rows are _not_ a grid, and going down from the middle of one row should put the user focus to the start of the next row.
 
@@ -82,7 +82,7 @@ navigation
   .registerNode('grid-b-row-2-col-2', { parent: 'grid-b-row-2', isFocusable: true })
 ```
 
-## Recipe 4 - Cancelling moves due to external business logic
+## Recipe 4 - Cancelling moves due to external business logic
 
 Perhaps you have a system where you only want a user to be able to navigate to a specific section of a page/app if some external logic authorizes and allows that move.
 


### PR DESCRIPTION
## Description
Headings 2 and 4 were displaying as "## Recipe 2..." for some reason. Deleting and re-typing the hashes seems to fix it.

## Motivation and Context
Make them display as `<h2>` tags.

## How Has This Been Tested?
Markdown Preview in VSCode.

## Types of changes
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
