### PR TITLE
Make keyCode optional in KeyEvent interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -38,7 +38,7 @@ export interface Override {
 }
 
 export interface KeyEvent {
-    keyCode: number;
+    keyCode?: number;
     direction: string;
 }
 


### PR DESCRIPTION
## Description
Make keyCode optional in KeyEvent interface. The code falls back to direction if none is provided anyway. See [src/index.ts Line 631](https://github.com/bbc/lrud/blob/master/src/index.ts#L631).

## Motivation and Context
Closes https://github.com/bbc/lrud/issues/65.

## How Has This Been Tested?
I ran `npm test`. I'd appreciate advice on how this might impact other users of LRUD though.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
