### PR TITLE
Emit active event when registering a node

### DIFF
--- a/src/events.test.js
+++ b/src/events.test.js
@@ -56,6 +56,38 @@ describe('event scenarios', () => {
 
     expect(activeSpy.mock.calls).toEqual([
       [expect.objectContaining({
+        parent: 'root',
+        id: 'left',
+        index: 0,
+        activeChild: 'a',
+        children: {
+          a: {
+            parent: 'left',
+            isFocusable: true,
+            id: 'a',
+            index: 0
+          },
+          b: {
+            parent: 'left',
+            isFocusable: true,
+            id: 'b',
+            index: 1
+          }
+        }
+      })],
+      [expect.objectContaining({
+        parent: 'left',
+        isFocusable: true,
+        id: 'a',
+        index: 0
+      })],
+      [expect.objectContaining({
+        parent: 'right',
+        isFocusable: true,
+        id: 'c',
+        index: 0
+      })],
+      [expect.objectContaining({
         parent: 'right',
         isFocusable: true,
         id: 'd',

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,11 @@ export class Lrud {
     if (parentsChildPaths == null) {
       const parentPath = this.getPathForNodeId(node.parent)
       Set(this.tree, parentPath + '.activeChild', nodeId)
+      
+      this.emitter.emit('active', node)
+      if (node.onActive) {
+        node.onActive(node)
+      }
     }
 
     // if no `index` set, calculate it


### PR DESCRIPTION
## Description
When registering a node that is the first child, emit an 'active' event from index.ts.

## Motivation and Context
Gives consistency between assigning focus and registering a node.

## How Has This Been Tested?
Updated existing tests to test new functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
