### PR TITLE
Fix(#55) focus removed when separate part of tree is removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ export class Lrud {
     if (parentsChildPaths == null) {
       const parentPath = this.getPathForNodeId(node.parent)
       Set(this.tree, parentPath + '.activeChild', nodeId)
-      
+
       this.emitter.emit('active', node)
       if (node.onActive) {
         node.onActive(node)
@@ -266,14 +266,19 @@ export class Lrud {
     }
 
     // ...if we're unregistering the activeChild of our parent (could be a leaf OR branch)
-    // we need to recalculate the focus...
+    // we might need to recalculate the focus...
     if (parentNode.activeChild && parentNode.activeChild === nodeId) {
       this.isIndexAlignMode = false
       delete parentNode.activeChild
 
-      if (unregisterOptions.forceRefocus) {
+      // check if the current focus node was removed
+      const isCurrentFocusNodeRemoved = !this.focusableNodePathList.some(nodeIdPath => {
+        return nodeIdPath.indexOf(this.currentFocusNodeId) > -1
+      })
+
+      if (unregisterOptions.forceRefocus && isCurrentFocusNodeRemoved) {
         this.recalculateFocus(nodeClone)
-      } else {
+      } else if (isCurrentFocusNodeRemoved) {
         this.currentFocusNode = undefined
         this.currentFocusNodeId = undefined
         this.currentFocusNodeIndex = undefined

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -494,7 +494,46 @@ describe('unregisterNode()', () => {
     ])
   })
 
-  test('unregistering a pibling of the focused node', () => {
+  test('unregistering a pibling of the focused node should not recalculate focus', () => {
+    const nav = new Lrud()
+
+    nav.register('root', {
+      orientation: 'horizontal'
+    })
+
+    nav.register('node1', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+
+    nav.register('item1', {
+      parent: 'node1',
+      selectAction: {},
+    })
+
+    nav.register('node2', {
+      orientation: 'vertical',
+      parent: 'root'
+    })
+
+    const onBlur = jest.fn();
+    nav.register('item2', {
+      parent: 'node2',
+      selectAction: {},
+      onBlur
+    })
+
+    nav.assignFocus('node2')
+
+    expect(nav.currentFocusNodeId).toEqual('item2')
+
+    nav.unregisterNode('item1')
+
+    expect(nav.currentFocusNodeId).toEqual('item2')
+    expect(onBlur).not.toBeCalled();
+  })
+
+  test('unregistering a pibling of the focused node should not remove focus - forceRefocus false', () => {
     const nav = new Lrud()
 
     nav.register('root', {
@@ -525,7 +564,7 @@ describe('unregisterNode()', () => {
 
     expect(nav.currentFocusNodeId).toEqual('item2')
 
-    nav.unregisterNode('item1')
+    nav.unregisterNode('item1', { forceRefocus: false })
 
     expect(nav.currentFocusNodeId).toEqual('item2')
   })


### PR DESCRIPTION
## Description
According to the docs: `unregisterOptions.forceRefocus if true, LRUD will attempt to re-focus on a new node if the currently focused node becomes unregistered due to the given node ID being unregistered`

This was not true, it always recalculated the focus regardless of if the focused node was actually removed, it also removed the focus completely even if the focused node wasn't removed.

## Motivation and Context
This fixes #55 
If the focused node isn't removed there is no need to remove focus, the expected behavior I think is that focus remains if possible. The focus was also recalculated even if the focused node wasn't removed.

## How Has This Been Tested?
Tested in the application I've been building
Added a unit-test and modified a unit-test to be more precise.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
