### PR TITLE
Fixing infinite climbUp, fixes #79

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,9 @@ export class Lrud {
    * @param {string} nodeId
    */
   getPathForNodeId (nodeId: string): string {
+    if (!nodeId) {
+      return undefined
+    }
     if (nodeId === this.rootNodeId) {
       return this.rootNodeId
     }

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -146,6 +146,19 @@ describe('lrud', () => {
       // and the next thing that was horizontal was the page
       expect(nextActionableNode.id).toEqual('page')
     })
+
+    test('should avoid infinite scan when root node reached', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root', {orientation: 'horizontal'})
+      navigation.registerNode('undefined', {parent: 'root', isFocusable: true})
+
+      navigation.assignFocus('undefined')
+
+      expect(
+        () => navigation.climbUp(navigation.getNode('undefined'), 'right')
+      ).not.toThrow({name: 'RangeError', message: 'Maximum call stack size exceeded'})
+    })
   })
 
   describe('getNextChildInDirection()', () => {
@@ -755,6 +768,22 @@ describe('lrud', () => {
       navigation.assignFocus('b')
       navigation.setNodeFocusable('b', false)
       expect(navigation.getNode('a').activeChild).toEqual('c')
+    })
+  })
+
+  describe('getPathForNodeId()', () => {
+    test('should return undefined - nodeId is not defined', () => {
+      const navigation = new Lrud()
+
+      navigation.registerNode('root')
+      navigation.registerNode('undefined', { })
+      navigation.registerNode('null', { })
+
+      expect(navigation.getPathForNodeId('undefined')).toEqual('root.children.undefined')
+      expect(navigation.getPathForNodeId(undefined)).toBeUndefined()
+
+      expect(navigation.getPathForNodeId('null')).toEqual('root.children.null')
+      expect(navigation.getPathForNodeId(null)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
This PR fixes node path resolution when given `nodeId` is not defined.

## Description
`getPathForNodeId` method didn't check whether provided `nodeId` is defined or not. As a result it was looking for node paths ending with `'.undefined'` or `'.null'`. If nodes with such ids exist then `climbUp` method was making infinite scan failing with `Maximum call stack size exceeded` error. When `root` node was reached, the climbing should stop, but instead `root`'s `undefined` parent was resolved as path to node with `'undefined'` id (string with 9 chars word) and climbing was continued until, again, `root` node was reached, and the story begins.

## Motivation and Context
Having nodes with `'undefined'` or `'null'` ids is not common situation, and may point that similar bug (concatenating `null`/`undefined` variable with string) is somewhere in LRUD user's code. Nevertheless, `'undefined'` and `'null'` are fully-flagged ids that shouldn't cause infinite climbing.

## How Has This Been Tested?
Fix was tested by unit tests and manually in app using LRUD library where such issue was found.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
