### PR TITLE
Improving the way of dealing with non-focusable nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .rpt2_cache
 dist
+.idea
 
 # Created by https://www.gitignore.io/api/node,macos
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,6 +119,25 @@ Used in conjuction with `isIndexAlign` behaviour, allows a node to replicate the
 
 For further details, see the [docs on index alignment](./index-align.md).
 
+### `isStopPropagate`
+
+`boolean`
+
+Allows dealing with a situation when focusable parent contains focusable children.
+
+By default, the leaf is picked to be focused, "the deepest" focusable candidate. In such case parent node is simply not a hindrance. Setting `isStopPropagate` to `true` inverts this behaviour. Parent node grabs focus instead of passing it to the children.
+
+```js
+navigation
+    .registerNode('row-1', { orientation: 'horizontal', isFocusable: true })
+    .registerNode('row-2', { orientation: 'horizontal', isFocusable: true })
+    .registerNode('row-2-item-1', { parent: 'row-2', isFocusable: true })
+    .registerNode('row-3', { orientation: 'horizontal', isFocusable: true, isStopPropagate: true })
+    .registerNode('row-3-item-2', { parent: 'row-3', isFocusable: true })
+```
+
+In the above example, if the user was focused on `row-1`, and LRUD handled an event with a direction of `down`, than `row-2-item-1` will be focused, because by default `row-2` passes focus to the children. Next event with a direction of `down` will move focus to `row-3`. This is because, `row-3` has `isStopPropagate` set to `true` which allowed him to grab the focus instead of passing it to the `row-3-item-2`, even if it's a focusable leaf.
+
 ---
 
 Several functions can also be given as registration options to a node. These functions will be called at specific state change points for the node. See our [Process Lifecycles doc](./process-lifecycles.md) for further details on the "lifecycle" of a move event in LRUD.
@@ -227,8 +246,7 @@ You can pass key events into LRUD using the `navigation.handleKeyEvent` function
 
 ```js
 document.onkeydown = function (event) {
-    navigation.handleKeyEvent(event)
-  }
+  navigation.handleKeyEvent(event)
 }
 ```
 

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -52,12 +52,21 @@ describe('event scenarios', () => {
       .registerNode('c', { parent: 'right', isFocusable: true })
       .registerNode('d', { parent: 'right', isFocusable: true })
 
+    navigation.assignFocus('a')
     navigation.assignFocus('d')
 
     expect(activeSpy.mock.calls).toEqual([
-      [expect.objectContaining({
-        parent: 'root',
+      // 'a' is focused, 'a' became active
+      [{
+        parent: 'left',
+        isFocusable: true,
+        id: 'a',
+        index: 0
+      }],
+      // bubbling to parent of 'a', 'left' became active
+      [{
         id: 'left',
+        parent: 'root',
         index: 0,
         activeChild: 'a',
         children: {
@@ -74,26 +83,16 @@ describe('event scenarios', () => {
             index: 1
           }
         }
-      })],
-      [expect.objectContaining({
-        parent: 'left',
-        isFocusable: true,
-        id: 'a',
-        index: 0
-      })],
-      [expect.objectContaining({
-        parent: 'right',
-        isFocusable: true,
-        id: 'c',
-        index: 0
-      })],
-      [expect.objectContaining({
+      }],
+      // changing focus from 'a' to 'd', 'd' became active
+      [{
         parent: 'right',
         isFocusable: true,
         id: 'd',
         index: 1
-      })],
-      [expect.objectContaining({
+      }],
+      // bubbling to parent of 'd', 'right' became active
+      [{
         id: 'right',
         parent: 'root',
         index: 1,
@@ -112,17 +111,12 @@ describe('event scenarios', () => {
             index: 1
           }
         }
-      })]
+      }]
     ])
 
     expect(inactiveSpy.mock.calls).toEqual([
-      [expect.objectContaining({
-        parent: 'right',
-        isFocusable: true,
-        id: 'c',
-        index: 0
-      })],
-      [expect.objectContaining({
+      // changing focus from 'a' to 'd', 'left' (parent of 'a') became inactive, because 'right' (parent of 'd') is active now
+      [{
         id: 'left',
         parent: 'root',
         index: 0,
@@ -141,7 +135,7 @@ describe('event scenarios', () => {
             index: 1
           }
         }
-      })]
+      }]
     ])
   })
 

--- a/src/focus-on-empty-node.test.js
+++ b/src/focus-on-empty-node.test.js
@@ -249,4 +249,81 @@ describe('Focusing on empty nodes', () => {
 
     expect(nav.currentFocusNodeId).toEqual('item4')
   })
+
+  /**
+   * @see https://github.com/bbc/lrud/issues/81
+   */
+  test('should jump to first focusable node in other branch', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { orientation: 'vertical' })
+    navigation.registerNode('a', { parent: 'root', orientation: 'vertical' })
+    navigation.registerNode('aa', { parent: 'a', isFocusable: true })
+    navigation.registerNode('ab', { parent: 'a' })
+    navigation.registerNode('b', { parent: 'root', orientation: 'vertical' })
+    navigation.registerNode('ba', { parent: 'b', isFocusable: true })
+    navigation.registerNode('bb', { parent: 'b', isFocusable: true })
+
+    navigation.assignFocus('aa')
+
+    navigation.handleKeyEvent({ direction: 'down' })
+
+    expect(navigation.currentFocusNodeId).toEqual('ba')
+  })
+
+  /**
+   * @see https://github.com/bbc/lrud/issues/82
+   */
+  test('should focus node with only non focusable children', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { orientation: 'vertical' })
+    navigation.registerNode('a', { parent: 'root', isFocusable: true })
+    navigation.registerNode('aa', { parent: 'a' })
+
+    navigation.assignFocus('a')
+
+    expect(navigation.currentFocusNodeId).toEqual('a')
+  })
+
+  /**
+   * @see https://github.com/bbc/lrud/issues/76
+   */
+  test('should jump over wrong orientation to first focusable node in other branch - vertical', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { orientation: 'vertical' })
+    navigation.registerNode('a', { parent: 'root', orientation: 'horizontal' })
+    navigation.registerNode('aa', { parent: 'a' })
+    navigation.registerNode('ab', { parent: 'a', isFocusable: true })
+    navigation.registerNode('ac', { parent: 'a' })
+    navigation.registerNode('b', { parent: 'root', isFocusable: true })
+
+    navigation.assignFocus('b')
+
+    navigation.handleKeyEvent({ direction: 'up' })
+
+    expect(navigation.currentFocusNodeId).toEqual('ab')
+  })
+
+  /**
+   * @see https://github.com/bbc/lrud/issues/56
+   */
+  test('should jump over wrong orientation to first focusable node in other branch - horizontal', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { orientation: 'horizontal' })
+    navigation.registerNode('a', { parent: 'root', orientation: 'vertical' })
+    navigation.registerNode('aa', { parent: 'a', isFocusable: true })
+    navigation.registerNode('b', { parent: 'root', orientation: 'vertical' })
+    navigation.registerNode('ba', { parent: 'b', orientation: 'horizontal' })
+    navigation.registerNode('bb', { parent: 'b', orientation: 'horizontal' })
+    navigation.registerNode('bba', { parent: 'bb', isFocusable: true })
+
+    navigation.assignFocus('aa')
+
+    navigation.handleKeyEvent({ direction: 'right' })
+
+    expect(navigation.currentFocusNodeId).toEqual('bba')
+  })
 })

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,6 +10,7 @@ export interface Node {
     selectAction?: any;
     isFocusable?: boolean;
     isWrapping?: boolean;
+    isStopPropagate?: boolean;
     orientation?: string;
     isIndexAlign?: boolean;
     onLeave?: (leave: Node) => void;

--- a/src/on-active-change.test.js
+++ b/src/on-active-change.test.js
@@ -50,14 +50,27 @@ describe('onActiveChildChange() tests', () => {
     navigation.handleKeyEvent({ direction: 'down' })
     navigation.handleKeyEvent({ direction: 'right' })
 
-    // 1st is by going from a to b
+    // 1st assigning focus to 'a'
     expect(spy.mock.calls[0][0].node.id).toEqual('left-col')
-    expect(spy.mock.calls[0][0].leave.id).toEqual('a')
-    expect(spy.mock.calls[0][0].enter.id).toEqual('b')
-
-    // 2nd is by going right to the 2nd column
+    expect(spy.mock.calls[0][0].leave).toBeFalsy()
+    expect(spy.mock.calls[0][0].enter.id).toEqual('a')
+    // ...bubbling
     expect(spy.mock.calls[1][0].node.id).toEqual('root')
-    expect(spy.mock.calls[1][0].leave.id).toEqual('left-col')
-    expect(spy.mock.calls[1][0].enter.id).toEqual('right-col')
+    expect(spy.mock.calls[1][0].leave).toBeFalsy()
+    expect(spy.mock.calls[1][0].enter.id).toEqual('left-col')
+
+    // 2nd is by going down to 'b'
+    expect(spy.mock.calls[2][0].node.id).toEqual('left-col')
+    expect(spy.mock.calls[2][0].leave.id).toEqual('a')
+    expect(spy.mock.calls[2][0].enter.id).toEqual('b')
+
+    // 3nd is by going right to 'd'
+    expect(spy.mock.calls[3][0].node.id).toEqual('right-col')
+    expect(spy.mock.calls[3][0].leave).toBeFalsy()
+    expect(spy.mock.calls[3][0].enter.id).toEqual('d')
+    // ...bubbling
+    expect(spy.mock.calls[4][0].node.id).toEqual('root')
+    expect(spy.mock.calls[4][0].leave.id).toEqual('left-col')
+    expect(spy.mock.calls[4][0].enter.id).toEqual('right-col')
   })
 })

--- a/src/register.test.js
+++ b/src/register.test.js
@@ -44,13 +44,9 @@ describe('registerNode()', () => {
     navigation.registerNode('beta_beta', { c: 3})
     navigation.registerNode('beta', { b: 2 })
 
-    // add a child to beta_beta so that activeChild won't be null if beta is identified as beta_beta
-    // when the activeChild is set during registration
-    navigation.registerNode('charlie', { d: 4, parent: 'beta_beta' })
-    navigation.registerNode('delta', { d: 4, parent: 'beta' })
+    navigation.registerNode('charlie', { d: 4, parent: 'beta' })
 
-    expect(navigation.tree.alpha.children.beta.children.delta).toBeTruthy();
-    expect(navigation.tree.alpha.children.beta.activeChild).toEqual('delta')
+    expect(navigation.tree.alpha.children.beta.children.charlie).toBeTruthy()
   })
 
   test('registering a node with a deeply nested parent', () => {
@@ -69,7 +65,7 @@ describe('registerNode()', () => {
   })
 
   // reword this
-  test('registering a new node with a parent that has no children sets its parent.activeChild to itself', () => {
+  test('registering a new node with a parent that has no children should not set parent.activeChild to itself', () => {
     const navigation = new Lrud()
 
     navigation.registerNode('root')
@@ -79,13 +75,9 @@ describe('registerNode()', () => {
     navigation.registerNode('delta', { parent: 'charlie' })
     navigation.registerNode('echo', { parent: 'root' })
 
-    // 'root' should have 3 children and its activeChild should be 'alpha'
-    // 'alpha' should have 1 children and its activeChild should be 'charlie'
-    // 'charlie' should have 1 children and its activeChild should be 'delta'
-
-    expect(navigation.getNode('root').activeChild).toEqual('alpha')
-    expect(navigation.getNode('alpha').activeChild).toEqual('charlie')
-    expect(navigation.getNode('charlie').activeChild).toEqual('delta')
+    expect(navigation.getNode('root').activeChild).toBeUndefined()
+    expect(navigation.getNode('alpha').activeChild).toBeUndefined()
+    expect(navigation.getNode('charlie').activeChild).toBeUndefined()
   })
 
   test('registering a node should add the index to the node', () => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -5,8 +5,10 @@ const {
   isNodeFocusable,
   isDirectionAndOrientationMatching,
   getDirectionForKeyCode,
-  isNodeInPath,
-  isNodeInPaths,
+  isNodeIdTheLeafOfPath,
+  isNodeIdInTheMiddleOfPath,
+  isNodeIdTheRootOfPath,
+  isNodeIdInPath,
   _findChildWithMatchingIndexRange,
   _findChildWithClosestIndex,
   _findChildWithIndex,
@@ -107,11 +109,17 @@ describe('isDirectionAndOrientationMatching()', () => {
   test('vertical and down is true', () => {
     expect(isDirectionAndOrientationMatching('vertical', 'down')).toEqual(true)
   })
+  test('vertical and * is true', () => {
+    expect(isDirectionAndOrientationMatching('vertical', '*')).toEqual(true)
+  })
   test('horizontal and left is true', () => {
     expect(isDirectionAndOrientationMatching('horizontal', 'left')).toEqual(true)
   })
   test('horizontal and right is true', () => {
     expect(isDirectionAndOrientationMatching('horizontal', 'right')).toEqual(true)
+  })
+  test('horizontal and * is true', () => {
+    expect(isDirectionAndOrientationMatching('horizontal', '*')).toEqual(true)
   })
   test('vertical and left is false', () => {
     expect(isDirectionAndOrientationMatching('vertical', 'left')).toEqual(false)
@@ -125,63 +133,86 @@ describe('isDirectionAndOrientationMatching()', () => {
   test('horizontal and down is false', () => {
     expect(isDirectionAndOrientationMatching('horizontal', 'down')).toEqual(false)
   })
+  test('undefined orientation and any valid direction is false', () => {
+    expect(isDirectionAndOrientationMatching(undefined, '*')).toEqual(false)
+  })
+  test('any valid orientation and undefined direction is false', () => {
+    expect(isDirectionAndOrientationMatching('horizontal', undefined)).toEqual(false)
+  })
 })
 
-describe('isNodeInPath()', () => {
-  it('node id is halfway through path', () => {
-    const node = {
-      id: 'y'
-    }
-    const path = 'x.y.z'
+describe('isNodeIdTheRootOfPath()', () => {
+  test('node id is root of path', () => {
+    expect(isNodeIdTheRootOfPath('x.y.z', 'x')).toEqual(true)
+  })
 
-    expect(isNodeInPath(path, node)).toEqual(true)
+  test('node id is not root of path', () => {
+    expect(isNodeIdTheRootOfPath('x.y.z', 'y')).toEqual(false)
+    expect(isNodeIdTheRootOfPath('x.y.z', 'z')).toEqual(false)
+  })
+
+  test('undefined node id is not root of path', () => {
+    expect(isNodeIdTheRootOfPath('x.y.z', undefined)).toEqual(false)
+  })
+
+  test('undefined path is false', () => {
+    expect(isNodeIdTheRootOfPath(undefined, 'x')).toEqual(false)
+  })
+})
+
+describe('isNodeIdInTheMiddleOfPath()', () => {
+  test('node id in the middle of path', () => {
+    expect(isNodeIdInTheMiddleOfPath('x.y.z', 'y')).toEqual(true)
+  })
+
+  test('node id is not in the middle of path', () => {
+    expect(isNodeIdInTheMiddleOfPath('x.y.z', 'x')).toEqual(false)
+    expect(isNodeIdInTheMiddleOfPath('x.y.z', 'z')).toEqual(false)
+  })
+
+  test('undefined node id is not in the middle of path', () => {
+    expect(isNodeIdInTheMiddleOfPath('x.y.z', null)).toEqual(false)
+  })
+
+  test('undefined path is false', () => {
+    expect(isNodeIdInTheMiddleOfPath(undefined, 'x')).toEqual(false)
+  })
+})
+
+describe('isNodeIdTheLeafOfPath()', () => {
+  test('node id is leaf of path', () => {
+    expect(isNodeIdTheLeafOfPath('x.y.z', 'z')).toEqual(true)
+  })
+
+  test('node id is not leaf of path', () => {
+    expect(isNodeIdTheLeafOfPath('x.y.z', 'x')).toEqual(false)
+    expect(isNodeIdTheLeafOfPath('x.y.z', 'y')).toEqual(false)
+  })
+
+  test('undefined node id is not leaf of path', () => {
+    expect(isNodeIdTheLeafOfPath('x.y.z', undefined)).toEqual(false)
+  })
+
+  test('undefined path is false', () => {
+    expect(isNodeIdTheLeafOfPath(undefined, 'x')).toEqual(false)
+  })
+})
+
+describe('isNodeIdInPath()', () => {
+  it('node id is halfway through path', () => {
+    expect(isNodeIdInPath('x.y.z', 'y')).toEqual(true)
   })
 
   it('node id is at start of path', () => {
-    const node = {
-      id: 'x'
-    }
-    const path = 'x.y.z'
-
-    expect(isNodeInPath(path, node)).toEqual(true)
+    expect(isNodeIdInPath('x.y.z', 'x')).toEqual(true)
   })
 
   it('node id is at end of path', () => {
-    const node = {
-      id: 'z'
-    }
-    const path = 'x.y.z'
-
-    expect(isNodeInPath(path, node)).toEqual(true)
+    expect(isNodeIdInPath('x.y.z', 'z')).toEqual(true)
   })
 
   it('node id is not in path', () => {
-    const node = {
-      id: 'z'
-    }
-    const path = '1.2.3'
-
-    expect(isNodeInPath(path, node)).toEqual(false)
-  })
-})
-
-describe('isNodeInPaths()', () => {
-  it('node id is in one of paths', () => {
-    const node = {
-      id: 'y'
-    }
-    const paths = ['x.y.z', 'a.b.c']
-
-    expect(isNodeInPaths(paths, node)).toEqual(true)
-  })
-
-  it('node id is not in one of paths', () => {
-    const node = {
-      id: 'y'
-    }
-    const paths = ['1.2.3', 'a.b.c']
-
-    expect(isNodeInPaths(paths, node)).toEqual(false)
+    expect(isNodeIdInPath('1.2.3', 'z')).toEqual(false)
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,34 +76,37 @@ export const isDirectionAndOrientationMatching = (orientation, direction): boole
 }
 
 /**
- * is the given node in the path, return true
+ * Checks if the given node is a root of the path.
  *
- * @param {*} node
+ * @param {string} path
+ * @param {string} nodeId
  */
-export const isNodeInPath = (path, node): boolean => {
-  if (path.lastIndexOf(node.id + '.', 0) === 0) {
-    return true
-  }
-  if (endsWith(path, '.' + node.id)) {
-    return true
-  }
-  if (path.indexOf('.' + node.id + '.') !== -1) {
-    return true
-  }
-
-  return false
-}
+export const isNodeIdTheRootOfPath = (path: string, nodeId: string): boolean => !!path && !!nodeId && path.lastIndexOf(nodeId + '.', 0) === 0
 
 /**
- * given an array of paths, return true if the node is in any of the paths
+ * Checks if the given node is a child in the middle of the path.
  *
- * @param {*} node
+ * @param {string} path
+ * @param {string} nodeId
  */
-export const isNodeInPaths = (paths, node): boolean => {
-  return paths.some(path => {
-    return isNodeInPath(path, node)
-  })
-}
+export const isNodeIdInTheMiddleOfPath = (path: string, nodeId: string): boolean => !!path && !!nodeId && path.indexOf('.' + nodeId + '.') !== -1
+
+/**
+ * Checks if the given node is a leaf in the path.
+ *
+ * @param {string} path
+ * @param {string} nodeId
+ */
+export const isNodeIdTheLeafOfPath = (path: string, nodeId: string): boolean => !!path && !!nodeId && endsWith(path, '.' + nodeId)
+
+/**
+ * is the given node in the path, return true
+ *
+ * @param {string} path
+ * @param {string} nodeId
+ */
+export const isNodeIdInPath = (path: string, nodeId: string): boolean => isNodeIdTheRootOfPath(path, nodeId) || isNodeIdInTheMiddleOfPath(path, nodeId) || isNodeIdTheLeafOfPath(path, nodeId)
+
 
 /**
  * return a child from the given node whose indexRange encompases the given index


### PR DESCRIPTION
This PR changes the way of marking the node as an `activeChild` of a parent node.


## Description
There’s a bunch of issues with moving focus over non-focusable nodes in more complicated (nested) scenarios. To solve them it was needed to change to way (and the moment) of setting the `activeChild` property. For the purpose of this PR it's worth to define a new term:

> *Focusable candidate* is a node that can accept the focus; it needs to be a focusable node or contains at least one child that is a focusable candidate

It's worth to explain here also, that:

> *Focusable node* is a node that has `isFocusable` property set to `true` or has `selectAction` property defined having `isFocusable` property not defined at the same time.

### The `activeChild` property

All of them occurs because of the way how `activeChild` property is picked. By default, it is the first child that is added to the parent. The problem here is that the first child might not be focusable. As a result, when we try to move focus to such `activeChild` we end up with various errors depending on the way of navigating to this node.

The `activeChild` property is no more set automatically as first registered child. It is set when a child actually gets focused or became an activeChild (because child of the child gets focused, and so on...). Having that, to determine which child can be focused (if any), we are looking for a focusable candidate, a node that is focusable or contains at least one child that is a focusable candidate. This gives the certainty that `activeChild`, when set, always points to a node that can accept focus (be focused itself or pass focus to the children). Additionally, to have such condition met, `activeChild` property is unset when node, to which `activeChild` points, is changed to be not focusable or is unregistered. Of course, unsetting `activeChild` bubbles up to the root node, if needed.

To deal with non-focusable nodes, whenever we have to find "next" or "prev" node to be focused, we are looking for next/prev focusable candidate now. This allows to jump over non-focusable nodes no matter which direction is traversed.

This change should be considered as a breaking change. Some existing LRUD integrations may rely on a way how and when `activeChild` is defined, may read that field directly.

### Focusing non-leaves

This is very common that focusable node is not a leaf. In general, while traversing the tree, "the deepest" focusable candidate is chosen. If focusable node contains focusable child, then such parent is simply not a hindrance and a child is picked. This default behavior can be changed on a node by setting `isStopPropagate` property to `true`. With that focusable node will gain focus instead of passing it to the children. Moreover, such parent will gain focus when focused directly with `assignFocus`, no matter what value of `isStopPropagate` it has set.

Consider such test cases:
```
    test('should focus focusable child of focusable node when focused indirectly, focusing leaf', () => {
      const navigation = new Lrud()

      navigation.registerNode('root')
      navigation.registerNode('a', { parent: 'root', isFocusable: true, orientation: 'vertical' })
      navigation.registerNode('aa', { parent: 'a', isFocusable: true })

      navigation.assignFocus('root')

      expect(navigation.currentFocusNodeId).toEqual('aa')
    })

    test('should focus focusable node containing focusable children when focused indirectly when stop propagate enabled', () => {
      const navigation = new Lrud()

      navigation.registerNode('root')
      navigation.registerNode('a', { parent: 'root', isFocusable: true, isStopPropagate: true, orientation: 'vertical' })
      navigation.registerNode('aa', { parent: 'a', isFocusable: true })

      navigation.assignFocus('root')

      expect(navigation.currentFocusNodeId).toEqual('a')
    })

    test('should focus focusable node containing focusable children when focused directly', () => {
      const navigation = new Lrud()

      navigation.registerNode('root')
      navigation.registerNode('a', { parent: 'root', isFocusable: true, orientation: 'vertical' })
      navigation.registerNode('aa', { parent: 'a', isFocusable: true })

      navigation.assignFocus('a')

      expect(navigation.currentFocusNodeId).toEqual('a')
    })
```

This is a bug fix. Together with that fix, new feature is added. Appropriate documentation is updated.

### Focus out of nowhere

When the focus is not initially assigned to any node, then nothing is happening when user is pressing arrow keys. In some cases, it might be required to auto-initialize focus state on user input. To achieve that additional parameter was added to the `handleKeyEvent` method. This is `HandleKeyEventOptions` object. It defines `forceFocus` parameter, which when set to `true`, makes first focusable candidate node focused.

```js
document.onkeydown = function (event) {
  navigation.handleKeyEvent(event, { forceFocus: true })
}

```
With that, focus will be assigned to first focusable candidate.

This is a new feature. Appropriate documentation is updated.


## Motivation and Context
Issues #56, #76, #81 and #82.

## How Has This Been Tested?
Fix was tested by unit tests and manually in app using LRUD library where such issue was found.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
