### PR TITLE
Coherent way of maintaining the index value

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,7 +100,7 @@ navigation
 
 `boolean`
 
-Keeps index of the children coherent and compact. The child will be inserted at a given index position. All other children indices that are greater or equal to index of just registering node are shifted up by one. If index of the registering child is greater that current size of children list, than child is appended and its is set accordingly as last.   
+Keeps index of the children coherent and compact. The child is inserted at a given index position and all other children indices, that are greater or equal to index of just registering child, are shifted up by one. If index of the registering child is greater that current size of children list, than it is appended and its index is set accordingly as last.   
 
 ```js
 navigation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,46 +78,26 @@ In the above example, if the user was focused on `item-3`, and LRUD handled an e
 
 `number`
 
-The zero-based index of the node, relative to its siblings. If no idex is given, it will be set as the _next_ index under its parent.
-
-```js
-navigation
-    .registerNode('X', { parent: 'root' })
-    .registerNode('Y', { parent: 'root' })
-    .registerNode('Z', { parent: 'root' })
-
-// ...is the same as
-
-navigation
-    .registerNode('X', { parent: 'root', index: 0 })
-    .registerNode('Y', { parent: 'root', index: 1 })
-    .registerNode('Z', { parent: 'root', index: 2 })
-```
-
-`index` is used when calculating the "next" or "previous" node in a list.
-
-### `isIndexCoherent`
-
-`boolean`
-
-Keeps index of the children coherent and compact. The child is inserted at a given index position and all other children indices, that are greater or equal to index of just registering child, are shifted up by one. If index of the registering child is greater that current size of children list, than it is appended and its index is set accordingly as last.   
+The zero-based index of the node, relative to its siblings. Index is kept coherent and compact. If `index` value is provided, then the child is inserted at that position and all other children indices, that are greater or equal to provided index, are shifted up by one. If `index` of the registering child is greater that current size of children list or is not given at all, it will be set as the _next_ index under its parent.
 
 ```js
 navigation
     .registerNode('root', { isIndexCoherent: true })
-    .registerNode('A', { parent: 'root' })
-    .registerNode('B', { parent: 'root' })
-    .registerNode('C', { parent: 'root', index: 1 })
-    .registerNode('D', { parent: 'root', index: 4 })
+    .registerNode('A', { parent: 'root' }) // order: |A|
+    .registerNode('B', { parent: 'root' }) // order: A, |B|
+    .registerNode('C', { parent: 'root' }) // order: A, B, |C|
+    .registerNode('D', { parent: 'root' }) // order: A, B, C, |D|
 
-// ...is the same as
+// ...gives the same result as
 
 navigation
-    .registerNode('A', { parent: 'root', index: 0 })
-    .registerNode('C', { parent: 'root', index: 1 })
-    .registerNode('B', { parent: 'root', index: 2 })
-    .registerNode('D', { parent: 'root', index: 3 })
+    .registerNode('A', { parent: 'root', index: 0 }) // order: |A|
+    .registerNode('C', { parent: 'root', index: 1 }) // order: A, |C|
+    .registerNode('B', { parent: 'root', index: 1 }) // order: A, |B|, C
+    .registerNode('D', { parent: 'root', index: 9 }) // order: A, B, C, |D|
 ```
+
+`index` is used when calculating the "next" or "previous" node in a list.
 
 ### `isIndexAlign`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,29 @@ navigation
 
 `index` is used when calculating the "next" or "previous" node in a list.
 
+### `isIndexCoherent`
+
+`boolean`
+
+Keeps index of the children coherent and compact. The child will be inserted at a given index position. All other children indices that are greater or equal to index of just registering node are shifted up by one. If index of the registering child is greater that current size of children list, than child is appended and its is set accordingly as last.   
+
+```js
+navigation
+    .registerNode('root', { isIndexCoherent: true })
+    .registerNode('A', { parent: 'root' })
+    .registerNode('B', { parent: 'root' })
+    .registerNode('C', { parent: 'root', index: 1 })
+    .registerNode('D', { parent: 'root', index: 4 })
+
+// ...is the same as
+
+navigation
+    .registerNode('A', { parent: 'root', index: 0 })
+    .registerNode('C', { parent: 'root', index: 1 })
+    .registerNode('B', { parent: 'root', index: 2 })
+    .registerNode('D', { parent: 'root', index: 3 })
+```
+
 ### `isIndexAlign`
 
 `boolean`

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export class Lrud {
       // if no `index` set, calculate it
       if (typeof node.index !== 'number') {
         node.index = parentsChildrenIds.length
-      } else if (parentNode.isIndexCoherent) {
+      } else {
         parentsChildrenIds.forEach(childId => {
           const child = parentNode.children[childId]
           if (child.index >= node.index) {
@@ -206,7 +206,7 @@ export class Lrud {
     Set(this.tree, path, node)
     this.nodePathList.push(path)
 
-    if (parentNode && parentNode.isIndexCoherent) {
+    if (parentNode) {
       this.reindexChildrenOfNode(parentNode)
     }
 
@@ -939,23 +939,11 @@ export class Lrud {
       replacementNode.parent = originalNode.parent
     }
 
-    const parentNode = this.getNode(replacementNode.parent)
-
     if (options.maintainIndex && originalNode && typeof originalNode.index === 'number') {
       replacementNode.index = originalNode.index
-      Object.keys(parentNode.children).forEach(childId => {
-        const child = parentNode.children[childId]
-        if (child.index >= originalNode.index) {
-          child.index += 1
-        }
-      })
     }
 
     this.registerTree(tree)
-
-    if (options.maintainIndex) {
-      this.reindexChildrenOfNode(parentNode)
-    }
   }
 
   doesNodeHaveFocusableChildren (node: Node): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export class Lrud {
     }
 
     // if no `index` set, calculate it
-    if (!node.index) {
+    if (typeof node.index !== 'number') {
       const parentNode = this.getNode(node.parent)
       if (parentNode) {
         const parentsChildren = this.getNode(node.parent).children
@@ -934,7 +934,7 @@ export class Lrud {
 
     const parentNode = this.getNode(replacementNode.parent)
 
-    if (options.maintainIndex && originalNode && originalNode.index) {
+    if (options.maintainIndex && originalNode && typeof originalNode.index === 'number') {
       replacementNode.index = originalNode.index
       Object.keys(parentNode.children).forEach(childId => {
         const child = parentNode.children[childId]

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -221,4 +221,53 @@ describe('insertTree()', () => {
     // expect index of the top node parent is maintained
     expect(navigation.getNode('a').index).toEqual(0)
   })
+
+  test('coherent index, keep parent\'s children indices coherent if index is not maintained', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { isIndexCoherent: true })
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('c', { parent: 'root' })
+    navigation.registerNode('d', { parent: 'root' })
+
+    navigation.insertTree({
+      c: {
+        parent: 'root',
+        index: 1,
+        isFocusable: true
+      }
+    }, { maintainIndex: false })
+
+    // expect top node was replaced with inserted tree
+    expect(navigation.getNode('c').isFocusable).toEqual(true)
+
+    // original 'c' was unregistered, so 'd' was shifted down to '2',
+    // but than new 'c' was inserted at '1', so 'd' was shifted up back to '3' and 'b' was shifted up to '2'
+    expect(navigation.getNode('a').index).toEqual(0)
+    expect(navigation.getNode('b').index).toEqual(2)
+    expect(navigation.getNode('c').index).toEqual(1)
+    expect(navigation.getNode('d').index).toEqual(3)
+  })
+
+  test('coherent index, should maintain original child index', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root', { isIndexCoherent: true })
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+
+    navigation.insertTree({
+      a: {
+        index: 5,
+        isFocusable: true
+      }
+    }, { maintainIndex: true })
+
+    // expect top node was replaced with inserted tree
+    expect(navigation.getNode('a').isFocusable).toEqual(true)
+
+    // existing 'a' node was unregistered, but its index is reassigned and kept by re-registered 'a' node
+    expect(navigation.getNode('a').index).toEqual(0)
+  })
 })

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -209,11 +209,15 @@ describe('insertTree()', () => {
     const navigation = new Lrud()
 
     navigation.registerNode('root')
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
-    navigation.registerNode('c', { parent: 'root' })
+    navigation.registerNode('a')
+    navigation.registerNode('b')
+    navigation.registerNode('c')
 
-    navigation.insertTree({ a: { parent: 'root', isFocusable: true } })
+    navigation.insertTree({
+      a: {
+        isFocusable: true
+      }
+    })
 
     // expect top node was replaced with inserted tree
     expect(navigation.getNode('a').isFocusable).toEqual(true)
@@ -225,15 +229,14 @@ describe('insertTree()', () => {
   test('coherent index, keep parent\'s children indices coherent if index is not maintained', () => {
     const navigation = new Lrud()
 
-    navigation.registerNode('root', { isIndexCoherent: true })
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
-    navigation.registerNode('c', { parent: 'root' })
-    navigation.registerNode('d', { parent: 'root' })
+    navigation.registerNode('root')
+    navigation.registerNode('a')
+    navigation.registerNode('b')
+    navigation.registerNode('c')
+    navigation.registerNode('d')
 
     navigation.insertTree({
       c: {
-        parent: 'root',
         index: 1,
         isFocusable: true
       }
@@ -250,19 +253,19 @@ describe('insertTree()', () => {
     expect(navigation.getNode('d').index).toEqual(3)
   })
 
-  test('coherent index, should maintain original child index', () => {
+  test('coherent index, should maintain original child index overriding provided index', () => {
     const navigation = new Lrud()
 
-    navigation.registerNode('root', { isIndexCoherent: true })
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('root')
+    navigation.registerNode('a')
+    navigation.registerNode('b')
 
     navigation.insertTree({
       a: {
         index: 5,
         isFocusable: true
       }
-    }, { maintainIndex: true })
+    })
 
     // expect top node was replaced with inserted tree
     expect(navigation.getNode('a').isFocusable).toEqual(true)

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -201,4 +201,24 @@ describe('insertTree()', () => {
     expect(instance.tree['root'].children['beta'].children['charlie']).toBeTruthy()
     expect(instance.tree['root'].children['beta'].children['charlie'].children).toBeTruthy()
   })
+
+  /**
+   * @see https://github.com/bbc/lrud/issues/84
+   */
+  test('should correctly maintain index when replacing first child', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root')
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('c', { parent: 'root' })
+
+    navigation.insertTree({ a: { parent: 'root', isFocusable: true } })
+
+    // expect top node was replaced with inserted tree
+    expect(navigation.getNode('a').isFocusable).toEqual(true)
+
+    // expect index of the top node parent is maintained
+    expect(navigation.getNode('a').index).toEqual(0)
+  })
 })

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,7 +12,6 @@ export interface Node {
     isWrapping?: boolean;
     orientation?: string;
     isIndexAlign?: boolean;
-    isIndexCoherent?: boolean;
     onLeave?: (leave: Node) => void;
     onEnter?: (enter: Node) => void;
     shouldCancelLeave?: (leave: Node, enter: Node) => boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,7 @@ export interface Node {
     isWrapping?: boolean;
     orientation?: string;
     isIndexAlign?: boolean;
+    isIndexCoherent?: boolean;
     onLeave?: (leave: Node) => void;
     onEnter?: (enter: Node) => void;
     shouldCancelLeave?: (leave: Node, enter: Node) => boolean;

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -297,10 +297,10 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 2, isFocusable: true })
-      navigation.registerNode('b', { index: 4, isFocusable: true })
-      navigation.registerNode('c', { index: 3, isFocusable: true })
-      navigation.registerNode('d', { index: 1, isFocusable: true })
+      navigation.registerNode('a', { index: 0, isFocusable: true }) // order: |a|
+      navigation.registerNode('b', { index: 1, isFocusable: true }) // order: a, |b|
+      navigation.registerNode('c', { index: 1, isFocusable: true }) // order: a, |c|, b
+      navigation.registerNode('d', { index: 0, isFocusable: true }) // order: |d|, a, c, b
 
       navigation.assignFocus('d')
 
@@ -313,10 +313,10 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 2, isFocusable: true })
-      navigation.registerNode('b', { index: 4, isFocusable: true })
-      navigation.registerNode('c', { index: 3, isFocusable: true })
-      navigation.registerNode('d', { index: 1, isFocusable: true })
+      navigation.registerNode('a', { index: 0, isFocusable: true }) // order: |a|
+      navigation.registerNode('b', { index: 1, isFocusable: true }) // order: a, |b|
+      navigation.registerNode('c', { index: 1, isFocusable: true }) // order: a, |c|, b
+      navigation.registerNode('d', { index: 0, isFocusable: true }) // order: |d|, a, c, b
 
       navigation.assignFocus('b')
 
@@ -347,10 +347,10 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 2, isFocusable: true })
-      navigation.registerNode('b', { index: 4, isFocusable: true })
-      navigation.registerNode('c', { index: 3, isFocusable: true })
-      navigation.registerNode('d', { index: 1, isFocusable: true })
+      navigation.registerNode('a', { index: 0, isFocusable: true }) // order: |a|
+      navigation.registerNode('b', { index: 1, isFocusable: true }) // order: a, |b|
+      navigation.registerNode('c', { index: 1, isFocusable: true }) // order: a, |c|, b
+      navigation.registerNode('d', { index: 0, isFocusable: true }) // order: |d|, a, c, b
 
       navigation.assignFocus('b')
 
@@ -363,10 +363,10 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 2, isFocusable: true })
-      navigation.registerNode('b', { index: 4, isFocusable: true })
-      navigation.registerNode('c', { index: 3, isFocusable: true })
-      navigation.registerNode('d', { index: 1, isFocusable: true })
+      navigation.registerNode('a', { index: 0, isFocusable: true }) // order: |a|
+      navigation.registerNode('b', { index: 1, isFocusable: true }) // order: a, |b|
+      navigation.registerNode('c', { index: 1, isFocusable: true }) // order: a, |c|, b
+      navigation.registerNode('d', { index: 0, isFocusable: true }) // order: |d|, a, c, b
 
       navigation.assignFocus('d')
 
@@ -424,9 +424,9 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 2 })
-      navigation.registerNode('b', { index: 1 })
-      navigation.registerNode('c', { index: 3 })
+      navigation.registerNode('a', { index: 0 }) // order: |a|
+      navigation.registerNode('b', { index: 0 }) // order: |b|, a
+      navigation.registerNode('c', { index: 2 }) // order: b, a, |c|
 
       const root = navigation.getNode('root')
 
@@ -437,17 +437,17 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 21 })
-      navigation.registerNode('b', { index: 10 })
-      navigation.registerNode('c', { index: 3 })
-      navigation.registerNode('d', { index: 5 })
-      navigation.registerNode('e', { index: 4 })
-      navigation.registerNode('f', { index: 7 })
-      navigation.registerNode('g', { index: 6 })
-      navigation.registerNode('h', { index: 9 })
-      navigation.registerNode('i', { index: 8 })
-      navigation.registerNode('j', { index: 15 })
-      navigation.registerNode('k', { index: 11 })
+      navigation.registerNode('a', { index: 0 }) // order: |a|
+      navigation.registerNode('b', { index: 0 }) // order: |b|, a
+      navigation.registerNode('c', { index: 0 }) // order: |c|, b, a
+      navigation.registerNode('d', { index: 1 }) // order: c, |d|, b, a
+      navigation.registerNode('e', { index: 1 }) // order: c, |e|, d, b, a
+      navigation.registerNode('f', { index: 3 }) // order: c, e, d, |f|, b, a
+      navigation.registerNode('g', { index: 3 }) // order: c, e, d, |g|, f, b, a
+      navigation.registerNode('h', { index: 5 }) // order: c, e, d, g, f, |h|, b, a
+      navigation.registerNode('i', { index: 5 }) // order: c, e, d, g, f, |i|, h, b, a
+      navigation.registerNode('j', { index: 8 }) // order: c, e, d, g, f, i, h, b, |j|, a
+      navigation.registerNode('k', { index: 8 }) // order: c, e, d, g, f, i, h, b, |k|, j, a
 
       const root = navigation.getNode('root')
 
@@ -493,9 +493,9 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 3 })
-      navigation.registerNode('b', { index: 1 })
-      navigation.registerNode('c', { index: 2 })
+      navigation.registerNode('a', { index: 0 }) // order: |a|
+      navigation.registerNode('b', { index: 0 }) // order: |b|, a
+      navigation.registerNode('c', { index: 1 }) // order: b, |c|, a
 
       const root = navigation.getNode('root')
 
@@ -506,17 +506,17 @@ describe('lrud', () => {
       const navigation = new Lrud()
 
       navigation.registerNode('root')
-      navigation.registerNode('a', { index: 3 })
-      navigation.registerNode('b', { index: 1 })
-      navigation.registerNode('c', { index: 2 })
-      navigation.registerNode('d', { index: 5 })
-      navigation.registerNode('e', { index: 8 })
-      navigation.registerNode('f', { index: 7 })
-      navigation.registerNode('g', { index: 3 })
-      navigation.registerNode('h', { index: 6 })
-      navigation.registerNode('i', { index: 9 })
-      navigation.registerNode('j', { index: 10 })
-      navigation.registerNode('k', { index: 11 })
+      navigation.registerNode('a', { index: 0 }) // order: |a|
+      navigation.registerNode('b', { index: 0 }) // order: |b|, a
+      navigation.registerNode('c', { index: 1 }) // order: b, |c|, a
+      navigation.registerNode('d', { index: 3 }) // order: b, c, a, |d|
+      navigation.registerNode('e', { index: 4 }) // order: b, c, a, d, |e|
+      navigation.registerNode('f', { index: 4 }) // order: b, c, a, d, |f|, e
+      navigation.registerNode('g', { index: 3 }) // order: b, c, a, |g|, d, f, e
+      navigation.registerNode('h', { index: 5 }) // order: b, c, a, g, d, |h|, f, e
+      navigation.registerNode('i', { index: 8 }) // order: b, c, a, g, d, h, f, e, |i|
+      navigation.registerNode('j', { index: 9 }) // order: b, c, a, g, d, h, f, e, i, |j|
+      navigation.registerNode('k', { index: 10 }) // order: b, c, a, g, d, h, f, e, i, j, |k|
 
       const root = navigation.getNode('root')
 
@@ -525,35 +525,16 @@ describe('lrud', () => {
   })
 
   describe('reindexChildrenOfNode', () => {
-    test('deleting a leaf should re-index the other leaves when leaves are added without indexes', () => {
+    test('deleting a child should re-index the other children', () => {
       const navigation = new Lrud()
 
       navigation
         .registerNode('root')
-        .registerNode('c', { index: 9 })
-        .registerNode('a', { index: 4 })
-        .registerNode('d', { index: 13 })
-        .registerNode('b', { index: 6 })
-
-      let root = navigation.getNode('root')
-      root = navigation.reindexChildrenOfNode(root)
-
-      expect(root.children.a.index).toEqual(0)
-      expect(root.children.b.index).toEqual(1)
-      expect(root.children.c.index).toEqual(2)
-      expect(root.children.d.index).toEqual(3)
-    })
-
-    test('test it through unregister', () => {
-      const navigation = new Lrud()
-
-      navigation
-        .registerNode('root')
-        .registerNode('c', { index: 9 })
-        .registerNode('a', { index: 4 })
-        .registerNode('e', { index: 16 })
-        .registerNode('d', { index: 13 })
-        .registerNode('b', { index: 6 })
+        .registerNode('c', { index: 0 }) // order: |c|
+        .registerNode('a', { index: 0 }) // order: |a|, c
+        .registerNode('e', { index: 2 }) // order: a, c, |e|
+        .registerNode('d', { index: 2 }) // order: a, c, |d|, e
+        .registerNode('b', { index: 1 }) // order: a, |b|, c, d, e
 
       navigation.unregisterNode('e')
 
@@ -568,17 +549,17 @@ describe('lrud', () => {
 
       navigation
         .registerNode('root')
-        .registerNode('c', { index: 9 })
-        .registerNode('a', { index: 4 })
-        .registerNode('e', { index: 16 })
-        .registerNode('d', { index: 13 })
-        .registerNode('b', { index: 6 })
-        .registerNode('f', { index: 10 })
-        .registerNode('g', { index: 20 })
-        .registerNode('h', { index: 17 })
-        .registerNode('i', { index: 15 })
-        .registerNode('j', { index: 3 })
-        .registerNode('k', { index: 1 })
+        .registerNode('c', { index: 0 }) // order: |c|
+        .registerNode('a', { index: 0 }) // order: |a|, c
+        .registerNode('e', { index: 2 }) // order: a, c, |e|
+        .registerNode('d', { index: 2 }) // order: a, c, |d|, e
+        .registerNode('b', { index: 1 }) // order: a, |b|, c, d, e
+        .registerNode('f', { index: 3 }) // order: a, b, c, |f|, d, e
+        .registerNode('g', { index: 6 }) // order: a, b, c, f, d, e, |g|
+        .registerNode('h', { index: 6 }) // order: a, b, c, f, d, e, |h|, g
+        .registerNode('i', { index: 5 }) // order: a, b, c, f, d, |i|, e, h, g
+        .registerNode('j', { index: 0 }) // order: |j|, a, b, c, f, d, i, e, h, g
+        .registerNode('k', { index: 0 }) // order: |k|, j, a, b, c, f, d, i, e, h, g
 
       navigation.unregisterNode('e')
 
@@ -588,6 +569,10 @@ describe('lrud', () => {
       expect(navigation.getNode('b').index).toEqual(3)
       expect(navigation.getNode('c').index).toEqual(4)
       expect(navigation.getNode('f').index).toEqual(5)
+      expect(navigation.getNode('d').index).toEqual(6)
+      expect(navigation.getNode('i').index).toEqual(7)
+      expect(navigation.getNode('h').index).toEqual(8)
+      expect(navigation.getNode('g').index).toEqual(9)
     })
   })
 

--- a/src/register.test.js
+++ b/src/register.test.js
@@ -137,33 +137,33 @@ describe('registerNode()', () => {
 
   test('coherent index, should assign last index value if no index value provided', () => {
     const navigation = new Lrud()
-    navigation.registerNode('root', { isIndexCoherent: true })
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('root')
+    navigation.registerNode('a')
+    navigation.registerNode('b')
 
-    navigation.registerNode('c', { parent: 'root' })
+    navigation.registerNode('c')
 
     expect(navigation.getNode('c').index).toEqual(2)
   })
 
   test('coherent index, should assign last index value even if given index is greater than children size', () => {
     const navigation = new Lrud()
-    navigation.registerNode('root', { isIndexCoherent: true })
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('root')
+    navigation.registerNode('a')
+    navigation.registerNode('b')
 
-    navigation.registerNode('c', { parent: 'root', index: 3 })
+    navigation.registerNode('c', { index: 3 })
 
     expect(navigation.getNode('c').index).toEqual(2)
   })
 
   test('coherent index, should insert node at a given position', () => {
     const navigation = new Lrud()
-    navigation.registerNode('root', { isIndexCoherent: true })
-    navigation.registerNode('a', { parent: 'root' })
-    navigation.registerNode('b', { parent: 'root' })
+    navigation.registerNode('root')
+    navigation.registerNode('a')
+    navigation.registerNode('b')
 
-    navigation.registerNode('c', { parent: 'root', index: 1 })
+    navigation.registerNode('c', { index: 1 })
 
     expect(navigation.getNode('c').index).toEqual(1)
     expect(navigation.getNode('b').index).toEqual(2)

--- a/src/register.test.js
+++ b/src/register.test.js
@@ -134,4 +134,38 @@ describe('registerNode()', () => {
       navigation.registerNode('root')
     }).toThrow()
   })
+
+  test('coherent index, should assign last index value if no index value provided', () => {
+    const navigation = new Lrud()
+    navigation.registerNode('root', { isIndexCoherent: true })
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+
+    navigation.registerNode('c', { parent: 'root' })
+
+    expect(navigation.getNode('c').index).toEqual(2)
+  })
+
+  test('coherent index, should assign last index value even if given index is greater than children size', () => {
+    const navigation = new Lrud()
+    navigation.registerNode('root', { isIndexCoherent: true })
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+
+    navigation.registerNode('c', { parent: 'root', index: 3 })
+
+    expect(navigation.getNode('c').index).toEqual(2)
+  })
+
+  test('coherent index, should insert node at a given position', () => {
+    const navigation = new Lrud()
+    navigation.registerNode('root', { isIndexCoherent: true })
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('b', { parent: 'root' })
+
+    navigation.registerNode('c', { parent: 'root', index: 1 })
+
+    expect(navigation.getNode('c').index).toEqual(1)
+    expect(navigation.getNode('b').index).toEqual(2)
+  })
 })


### PR DESCRIPTION
This PR fixes the way of checking if `index` property is defined and the way how index is calculated when registering the node.

## Description
Currently `index` property existence was simple verified be checking if such property is "truthy" or "falsy". For number it's wrong approach because '0' is "falsy", but on the other hand is a valid (defined) number.

It is also not possible to insert child at a given position. If given index value is already occupied by other child, than both children shares the same index value, which results in a bit weird behavior while searching for next or prev node. In such case the moment of registering takes precedence. To deal with that issue, the new property `isCoherentIndex ` is introduced. A node that has such property defined, keeps indices of its children coherent and compact. The child is inserted at a given index position and all other children indices that are greater or equal to index of just registering child are shifted up by one. If index of the registering child is greater than current size of children list, than child is appended and its index is set accordingly as last.  

## Motivation and Context
Issue #84, #88

## How Has This Been Tested?
Fix was tested by unit tests and manually in app using LRUD library where such issue was found.

## Screenshots (if appropriate):
No screenshots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
