### PR TITLE
Cleaning overrides of unregistered node and its children

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import {
   _findChildWithIndex,
   getNodesFromTree,
   endsWith,
-  arrayFind
+  arrayFind,
+  isNodeInTree
 } from './utils'
 
 import mitt from 'mitt'
@@ -313,11 +314,12 @@ export class Lrud {
       nodeClone.onBlur(nodeClone)
     }
 
-    // if we have any overrides whose target or ID is the node we just unregistered, we should unregister
+    // if we have any overrides whose target or ID is the node (or one of its children) we just unregistered, we should unregister
     // those overrides (thus keeping state clean)
+    const unregisteredSubTree = { [nodeClone.id]: nodeClone }
     Object.keys(this.overrides).forEach(overrideId => {
       const override = this.overrides[overrideId]
-      if (override.target === nodeClone.id || override.id === nodeClone.id) {
+      if (isNodeInTree(override.target, unregisteredSubTree) || isNodeInTree(override.id, unregisteredSubTree)) {
         this.unregisterOverride(overrideId)
       }
     })

--- a/src/unregister.test.js
+++ b/src/unregister.test.js
@@ -228,6 +228,28 @@ describe('unregisterNode()', () => {
     })
   })
 
+  /**
+   * @see https://github.com/bbc/lrud/issues/86
+   */
+  test('unregistering a node should unregister the overrides of its children', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root')
+    navigation.registerNode('a', { parent: 'root' })
+    navigation.registerNode('ab', { parent: 'a' })
+    navigation.registerNode('b', { parent: 'root' })
+
+    navigation.registerOverride('override_a', {
+      id: 'ab',
+      direction: 'right',
+      target: 'b'
+    })
+
+    navigation.unregister('a')
+
+    expect(navigation.overrides).toEqual({})
+  })
+
   test('unregistering a node that is the id of an override should unregister the override', () => {
     const navigation = new Lrud()
 


### PR DESCRIPTION
This PR improves the process of unregistering the node.

## Description
Together with node all its children are automatically unregistered as well. In general the whole sub-tree, where the unregistered node is a top node, is unregistered.
  Overrides have to be cleaned separately, because they are stored separately. This PR introduces more accurate check, which verifies does override relates not only to unregistered node but also to one of its children. 

## Motivation and Context
#86

## How Has This Been Tested?
Fix was tested by unit tests and manually in app using LRUD library where such issue was found.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
