### PR TITLE
Focusing first focusable node on key press, if no node focused yet

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,6 +229,12 @@ document.onkeydown = function (event) {
 }
 ```
 
+### Handling Key Events Options
+
+A config object can be given to `handleKeyEvent(<event>, <handleKeyEventOptions>)` to force specific behaviour.
+
+- `forceFocus:boolean` When `true`, if there's no focused node, then LRUD will attempt to find a first focusable candidate (the node that is focusable or contains at least one child that is a focusable candidate). Such node, when found, will be automatically focused and focus state of navigation tree is auto-initialized. The default value is `false`.
+
 ## Events
 
 LRUD emits events in response to key events. See the [TAL docs](http://bbc.github.io/tal/widgets/focus-management.html) for an explanation of 'focused' and 'active' nodes. Each of these callbacks is called with the node that changed state.

--- a/src/handle-key-event.test.js
+++ b/src/handle-key-event.test.js
@@ -191,4 +191,35 @@ describe('handleKeyEvent()', () => {
     navigation.handleKeyEvent({ direction: 'down' })
     expect(navigation.currentFocusNodeId).toEqual('list-b-box-2')
   })
+
+  test('no focused node, should not fail and do nothing', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root')
+    navigation.registerNode('a', { orientation: 'vertical' })
+    navigation.registerNode('aa', { parent: 'a' })
+    navigation.registerNode('ab', { parent: 'a', isFocusable: true })
+    navigation.registerNode('ac', { parent: 'a' })
+
+    expect(() => {
+      navigation.handleKeyEvent({ direction: 'down' })
+    }).not.toThrow()
+    expect(navigation.currentFocusNodeId).toEqual(null)
+  })
+
+  test('no focused node, should not fail and force focusing first focusable node', () => {
+    const navigation = new Lrud()
+
+    navigation.registerNode('root')
+    navigation.registerNode('a', { orientation: 'vertical' })
+    navigation.registerNode('aa', { parent: 'a' })
+    navigation.registerNode('ab', { parent: 'a', isFocusable: true })
+    navigation.registerNode('ac', { parent: 'a' })
+    navigation.registerNode('b', { isFocusable: true })
+
+    expect(() => {
+      navigation.handleKeyEvent({ direction: 'down' }, { forceFocus: true })
+    }).not.toThrow()
+    expect(navigation.currentFocusNodeId).toEqual('ab')
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Get } from './get'
 import { Set } from './set'
-import { Node, Override, KeyEvent, InsertTreeOptions, UnregisterNodeOptions } from './interfaces'
+import { Node, Override, KeyEvent, HandleKeyEventOptions, InsertTreeOptions, UnregisterNodeOptions } from './interfaces'
 
 import {
   isNodeFocusable,
@@ -654,8 +654,10 @@ export class Lrud {
    * @param {object} event
    * @param {string} [event.keyCode]
    * @param {string} [event.direction]
+   * @param {HandleKeyEventOptions} [options]
+   * @param {boolean} [options.forceFocus] - if <code>true</code> and there's no currently focused node, LRUD will try to focus first focusable node
    */
-  handleKeyEvent (event: KeyEvent): Node | void {
+  handleKeyEvent (event: KeyEvent, options: HandleKeyEventOptions = { forceFocus: false }): Node | void {
     const direction = (event.keyCode) ? getDirectionForKeyCode(event.keyCode) : event.direction.toUpperCase()
     const currentFocusNode = this.getNode(this.currentFocusNodeId)
 
@@ -668,29 +670,38 @@ export class Lrud {
       return
     }
 
-    // climb up from where we are...
-    const topNode = this.climbUp(currentFocusNode, direction)
+    let topNode: Node
+    let focusableNode: Node
 
-    // ... if we cant find a top node, its an invalid move - just return
-    if (!topNode) {
-      return
+    if (!currentFocusNode && options.forceFocus) {
+      // No node is focused,fFocusing first focusable node
+      topNode = this.getRootNode()
+      focusableNode = this.digDown(topNode)
+    } else {
+      // climb up from where we are...
+      topNode = this.climbUp(currentFocusNode, direction)
+
+      // ... if we cant find a top node, its an invalid move - just return
+      if (!topNode) {
+        return
+      }
+
+      // ...if we need to align indexes, turn the flag on now...
+      this.isIndexAlignMode = topNode.isIndexAlign === true
+
+      // ...get the top's next child in the direction we're going...
+      const nextChild = this.getNextChildInDirection(topNode, direction)
+
+      // ...and depending on if we're able to find a child, dig down from the child or from the original top...
+      focusableNode = (nextChild) ? this.digDown(nextChild, direction) : this.digDown(topNode, direction)
     }
-
-    // ...if we need to align indexes, turn the flag on now...
-    this.isIndexAlignMode = topNode.isIndexAlign === true
-
-    // ...get the top's next child in the direction we're going...
-    const nextChild = this.getNextChildInDirection(topNode, direction)
-
-    // ...and depending on if we're able to find a child, dig down from the child or from the original top...
-    const focusableNode: Node = (nextChild) ? this.digDown(nextChild, direction) : this.digDown(topNode, direction)
 
     if (!focusableNode) {
       return
     }
 
     // ...give an opportunity for the move to be cancelled by the leaving node
-    if (currentFocusNode.shouldCancelLeave) {
+    if (currentFocusNode && currentFocusNode.shouldCancelLeave) {
       if (currentFocusNode.shouldCancelLeave(currentFocusNode, focusableNode)) {
         if (currentFocusNode.onLeaveCancelled) {
           currentFocusNode.onLeaveCancelled(currentFocusNode, focusableNode)
@@ -738,7 +749,7 @@ export class Lrud {
       })
     }
 
-    if (currentFocusNode.onLeave) {
+    if (currentFocusNode && currentFocusNode.onLeave) {
       currentFocusNode.onLeave(currentFocusNode)
     }
     if (focusableNode.onEnter) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,6 +42,10 @@ export interface KeyEvent {
     direction: string;
 }
 
+export interface HandleKeyEventOptions {
+    forceFocus: boolean;
+}
+
 export interface InsertTreeOptions {
     maintainIndex: boolean;
 }


### PR DESCRIPTION
This PR introduces new option that improves handling key presses.

## Description

When the focus is not initially assigned to any node, then nothing is happening when user is pressing arrow keys. In some cases, it might be required to auto-initialize focus state on user input. To achieve that, additional parameter was added to the `handleKeyEvent` method. This is `HandleKeyEventOptions` object,  which defines `forceFocus` parameter. By default it's set to `false`. When set to `true`, than LRUD will attempt to find first focusable candidate - the node that is focusable or contains at least one child that is a focusable candidate. Such node, when found, will be automatically focused and focus state of navigation tree will be auto-initialized, e.g:

```
document.onkeydown = function (event) {
  navigation.handleKeyEvent(event, { forceFocus: true })
}
```

## Motivation and Context
It's just to improve user experience. When there's no currently focused node that user might feel that page got stuck.

## How Has This Been Tested?
It was tested by unit tests and manually in app using LRUD library where idea of such feature was born.

## Screenshots (if appropriate):
No screenshots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
