### PR TITLE
Fail safely, null/undefined checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -548,7 +548,7 @@ export class Lrud {
    * @param {object} node
    */
   getNextFocusableChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return
     }
     // there's no child that is (or was) focused, so we can quickly pick first focusable child
@@ -576,7 +576,7 @@ export class Lrud {
    * @param {object} node
    */
   getPrevFocusableChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return
     }
     // there's no child that is (or was) focused, so we can quickly pick last focusable child
@@ -605,7 +605,7 @@ export class Lrud {
    * @param {object} node
    */
   getNodeFirstChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return undefined
     }
 
@@ -620,7 +620,7 @@ export class Lrud {
    * @param {object} node
    */
   getNodeLastChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return undefined
     }
 
@@ -635,7 +635,7 @@ export class Lrud {
    * @param {object} node
    */
   getNodeFirstFocusableChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return undefined
     }
 
@@ -658,7 +658,7 @@ export class Lrud {
    * @param {object} node
    */
   getNodeLastFocusableChild (node: Node): Node {
-    if (!node.children) {
+    if (!node || !node.children) {
       return undefined
     }
 
@@ -798,7 +798,10 @@ export class Lrud {
   setActiveChild (parentId: string, childId: string): void {
     const child = this.getNode(childId)
     const parent = this.getNode(parentId)
-    if (!child) {
+    if (!parent || !child) {
+      return
+    }
+    if (child.parent !== parent.id) {
       return
     }
 
@@ -851,7 +854,7 @@ export class Lrud {
     const parent = this.getNode(parentId)
 
     // if the parent has a parent, bubble up
-    if (parent.parent) {
+    if (parent && parent.parent) {
       this.setActiveChildRecursive(parent.parent, parent.id)
     }
   }
@@ -865,7 +868,7 @@ export class Lrud {
    */
   unsetActiveChild (parentId: string, activeChildId: string): void {
     let parent = this.getNode(parentId)
-    if (!parent.activeChild) return
+    if (!parent || !parent.activeChild) return
     if (parent.activeChild !== activeChildId) return
 
     // activeChildId may be already deleted, creating its path manually
@@ -972,6 +975,7 @@ export class Lrud {
    * @param {object} tree
    */
   registerTree (tree: object): void {
+    if (!tree) return
     getNodesFromTree(tree).forEach(node => {
       this.registerNode(node.id, node)
     })
@@ -990,6 +994,7 @@ export class Lrud {
    * @param {object} options.maintainIndex if true, and new tree is replacing an existing branch of the tree, maintain the original branches relative index
    */
   insertTree (tree: object, options: InsertTreeOptions = { maintainIndex: true }): void {
+    if (!tree) return
     const replacementNode = tree[Object.keys(tree)[0]]
 
     if (!replacementNode.id) {
@@ -1009,6 +1014,7 @@ export class Lrud {
   }
 
   doesNodeHaveFocusableChildren (node: Node): boolean {
+    if (!node) return false
     return this.focusableNodePathList.some(path => isNodeIdTheRootOfPath(path, node.id) || isNodeIdInTheMiddleOfPath(path, node.id))
   }
 

--- a/src/insert-tree.test.js
+++ b/src/insert-tree.test.js
@@ -273,4 +273,11 @@ describe('insertTree()', () => {
     // existing 'a' node was unregistered, but its index is reassigned and kept by re-registered 'a' node
     expect(navigation.getNode('a').index).toEqual(0)
   })
+
+  test('should not fail when tree is not defined', () => {
+    const navigation = new Lrud()
+    navigation.registerNode('root')
+
+    expect(() => navigation.insertTree(undefined)).not.toThrow()
+  })
 })

--- a/src/lrud.test.js
+++ b/src/lrud.test.js
@@ -381,6 +381,18 @@ describe('lrud', () => {
 
       expect(nextFocusableChild).toBeUndefined()
     })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getNextFocusableChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
+    })
   })
 
   describe('getPrevFocusableChild()', () => {
@@ -445,6 +457,18 @@ describe('lrud', () => {
 
       expect(prevFocusableChild).toBeUndefined()
     })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getPrevFocusableChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
+    })
   })
 
   describe('getNodeFirstFocusableChild()', () => {
@@ -489,6 +513,18 @@ describe('lrud', () => {
 
       expect(firstFocusableChild).toBeUndefined()
     })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getNodeFirstFocusableChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
+    })
   })
 
   describe('getNodeLastFocusableChild()', () => {
@@ -532,6 +568,18 @@ describe('lrud', () => {
       }).not.toThrow()
 
       expect(lastFocusableChild).toBeUndefined()
+    })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getNodeLastFocusableChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
     })
   })
 
@@ -612,6 +660,18 @@ describe('lrud', () => {
 
       expect(navigation.getNodeFirstChild(root).id).toEqual('c')
     })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getNodeFirstChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
+    })
   })
 
   describe('getNodeLastChild()', () => {
@@ -680,6 +740,18 @@ describe('lrud', () => {
       const root = navigation.getNode('root')
 
       expect(navigation.getNodeLastChild(root).id).toEqual('k')
+    })
+
+    test('should not fail of node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      let nextFocusableChild = navigation.getRootNode()
+      expect(() => {
+        nextFocusableChild = navigation.getNodeLastChild(navigation.getNode('not_existing'))
+      }).not.toThrow()
+
+      expect(nextFocusableChild).toBeUndefined()
     })
   })
 
@@ -750,6 +822,41 @@ describe('lrud', () => {
       expect(navigation.currentFocusNodeId).toEqual('b0')
       expect(navigation.getNode('root').activeChild).toEqual('b')
     })
+
+    it('should not fail when parent does not exist', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      expect(() => navigation.setActiveChild('not_existing', 'a0')).not.toThrow()
+    })
+
+    it('should do nothing when child does not exist', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      navigation.assignFocus('a0')
+
+      expect(() => navigation.setActiveChild('a', 'not_existing')).not.toThrow()
+      expect(navigation.getNode('a').activeChild).toEqual('a0')
+    })
+
+    it('should do nothing when child is not direct child of parent', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+        .registerNode('b', { parent: 'root' })
+
+      expect(() => navigation.setActiveChild('b', 'a0')).not.toThrow()
+      expect(navigation.getNode('b').activeChild).toBeUndefined()
+    })
   })
 
   describe('setActiveChildRecursive', () => {
@@ -767,6 +874,70 @@ describe('lrud', () => {
       navigation.setActiveChildRecursive('a', 'a0')
       expect(navigation.currentFocusNodeId).toEqual('a1')
       expect(navigation.getNode('root').activeChild).toEqual('a')
+    })
+
+    it('should not fail when parent does not exist', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      expect(() => navigation.setActiveChildRecursive('not_existing', 'a0')).not.toThrow()
+    })
+  })
+
+  describe('unsetActiveChild', () => {
+    it('should recurse up the tree', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      navigation.assignFocus('a0')
+
+      navigation.unsetActiveChild('a', 'a0')
+      expect(navigation.getNode('a').activeChild).toBeUndefined()
+      expect(navigation.getNode('root').activeChild).toBeUndefined()
+    })
+
+    it('should not fail when parent does not exist', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      expect(() => navigation.unsetActiveChild('not_existing', 'a0')).not.toThrow()
+    })
+
+    it('should do nothing when child does not exist', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+
+      navigation.assignFocus('a0')
+
+      expect(() => navigation.unsetActiveChild('a', 'not_existing')).not.toThrow()
+      expect(navigation.getNode('a').activeChild).toEqual('a0')
+    })
+
+    it('should do nothing when child is not direct child of parent', () => {
+      const navigation = new Lrud()
+      navigation
+        .registerNode('root')
+        .registerNode('a', { parent: 'root' })
+        .registerNode('a0', { isFocusable: true, parent: 'a' })
+        .registerNode('b', { parent: 'root' })
+        .registerNode('b0', { isFocusable: true, parent: 'b' })
+
+      navigation.assignFocus('b0')
+
+      expect(() => navigation.unsetActiveChild('b', 'a0')).not.toThrow()
+      expect(navigation.getNode('b').activeChild).toEqual('b0')
     })
   })
 
@@ -917,6 +1088,13 @@ describe('lrud', () => {
       expect(navigation.getNode('a').activeChild).toBeUndefined()
       expect(navigation.getNode('root').activeChild).toBeUndefined()
     })
+
+    test('should not fail when node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+
+      expect(() => navigation.setNodeFocusable('not_existing', true)).not.toThrow()
+    })
   })
 
   describe('getPathForNodeId()', () => {
@@ -960,6 +1138,16 @@ describe('lrud', () => {
       expect(navigation.doesNodeHaveFocusableChildren(navigation.getNode('bb'))).toEqual(false)
       expect(navigation.doesNodeHaveFocusableChildren(navigation.getNode('c'))).toEqual(false)
     })
+
+    test('should not fail when node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+      navigation.registerNode('a', { isFocusable: true, parent: 'root' })
+
+      const notExistingNode = navigation.getNode('not_existing')
+      expect(() => navigation.doesNodeHaveFocusableChildren(notExistingNode)).not.toThrow()
+      expect(navigation.doesNodeHaveFocusableChildren(notExistingNode)).toEqual(false)
+    })
   })
 
   describe('isNodeFocusableCandidate()', () => {
@@ -986,6 +1174,16 @@ describe('lrud', () => {
       expect(navigation.isNodeFocusableCandidate(navigation.getNode('ba'))).toEqual(false)
       expect(navigation.isNodeFocusableCandidate(navigation.getNode('bb'))).toEqual(false)
       expect(navigation.isNodeFocusableCandidate(navigation.getNode('c'))).toEqual(true)
+    })
+
+    test('should not fail when node does not exists', () => {
+      const navigation = new Lrud()
+      navigation.registerNode('root')
+      navigation.registerNode('a', { isFocusable: true, parent: 'root' })
+
+      const notExistingNode = navigation.getNode('not_existing')
+      expect(() => navigation.isNodeFocusableCandidate(notExistingNode)).not.toThrow()
+      expect(navigation.isNodeFocusableCandidate(notExistingNode)).toEqual(false)
     })
   })
 })

--- a/src/multiple-instance-interaction.test.js
+++ b/src/multiple-instance-interaction.test.js
@@ -20,4 +20,11 @@ describe('registerTree()', () => {
     expect(Beta.tree.root.children.a).toBeTruthy()
     expect(Beta.tree.root.children.b).toBeTruthy()
   })
+
+  test('should not fail when tree is not defined', () => {
+    const navigation = new Lrud()
+    navigation.registerNode('root')
+
+    expect(() => navigation.registerTree(undefined)).not.toThrow()
+  })
 })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -12,7 +12,8 @@ const {
   _findChildWithMatchingIndexRange,
   _findChildWithClosestIndex,
   _findChildWithIndex,
-  isNodeInTree
+  isNodeInTree,
+  getNodesFromTree
 } = require('./utils')
 
 describe('Closest()', () => {
@@ -99,6 +100,12 @@ describe('isNodeFocusable()', () => {
     }
 
     expect(isNodeFocusable(node)).toEqual(false)
+  })
+
+  test('should not fail when node does not exists', () => {
+    const notExistingNode = undefined
+    expect(() => isNodeFocusable(notExistingNode)).not.toThrow()
+    expect(isNodeFocusable(notExistingNode)).toEqual(false)
   })
 })
 
@@ -214,6 +221,14 @@ describe('isNodeIdInPath()', () => {
   it('node id is not in path', () => {
     expect(isNodeIdInPath('1.2.3', 'z')).toEqual(false)
   })
+
+  it('node id is not defined', () => {
+    expect(isNodeIdInPath('1.2.3', undefined)).toEqual(false)
+  })
+
+  it('path is not defined', () => {
+    expect(isNodeIdInPath(undefined, 'z')).toEqual(false)
+  })
 })
 
 describe('_findChildWithMatchingIndexRange()', () => {
@@ -285,6 +300,11 @@ describe('_findChildWithMatchingIndexRange()', () => {
     const found = _findChildWithMatchingIndexRange(node, 6)
 
     expect(found).toEqual(null)
+  })
+
+  test('should not fail when node does not exists', () => {
+    const notExistingNode = undefined
+    expect(() => _findChildWithMatchingIndexRange(notExistingNode, 0)).not.toThrow()
   })
 })
 
@@ -501,6 +521,11 @@ describe('_findChildWithClosestIndex()', () => {
 
     expect(found).toEqual(node.children.d)
   })
+
+  test('should not fail when node does not exists', () => {
+    const notExistingNode = undefined
+    expect(() => _findChildWithClosestIndex(notExistingNode, 0)).not.toThrow()
+  })
 })
 
 describe('_findChildWithIndex()', () => {
@@ -604,6 +629,11 @@ describe('_findChildWithIndex()', () => {
     const found = _findChildWithIndex(node, 1)
     expect(found).toEqual(null)
   })
+
+  test('should not fail when node does not exists', () => {
+    const notExistingNode = undefined
+    expect(() => _findChildWithIndex(notExistingNode, 0)).not.toThrow()
+  })
 })
 
 describe('isNodeInTree()', () => {
@@ -685,6 +715,11 @@ describe('isNodeInTree()', () => {
 
     expect(isNodeInTree('node_x', tree)).toEqual(false)
   })
+
+  test('should not fail when tree is not defined', () => {
+    expect(() => isNodeInTree('node_x', undefined)).not.toThrow()
+    expect(isNodeInTree('node_x', undefined)).toEqual(false)
+  })
 })
 
 describe('getDirectionForKeyCode()', () => {
@@ -695,5 +730,12 @@ describe('getDirectionForKeyCode()', () => {
   it('get direction for unknown keycode', () => {
     const direction = getDirectionForKeyCode(999999999)
     expect(direction).toEqual(null)
+  })
+})
+
+describe('getNodesFromTree()', () => {
+  test('should not fail when tree is not defined', () => {
+    expect(() => getNodesFromTree(undefined)).not.toThrow()
+    expect(getNodesFromTree(undefined)).toEqual([])
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,10 @@ export const arrayFind = <A>(arr: A[], func): A | undefined => {
  *
  * @param {object} node
  */
-export const isNodeFocusable = (node: Node): boolean => node.isFocusable != null ? node.isFocusable : !!node.selectAction
+export const isNodeFocusable = (node: Node): boolean => {
+  if (!node) return false
+  return node.isFocusable != null ? node.isFocusable : !!node.selectAction
+}
 
 /**
  * given a keyCode, lookup and return the direction from the keycodes mapping file
@@ -115,7 +118,7 @@ export const isNodeIdInPath = (path: string, nodeId: string): boolean => isNodeI
  * @param {number} index
  */
 export const _findChildWithMatchingIndexRange = (node, index): Node => {
-  if (!node.children) {
+  if (!node || !node.children) {
     return null
   }
 
@@ -136,7 +139,7 @@ export const _findChildWithMatchingIndexRange = (node, index): Node => {
  * @param {number} index
  */
 export const _findChildWithIndex = (node, index): Node => {
-  if (!node.children) {
+  if (!node || !node.children) {
     return null
   }
 
@@ -162,7 +165,7 @@ export const _findChildWithIndex = (node, index): Node => {
  * @param {number[]} indexRange
  */
 export const _findChildWithClosestIndex = (node, index, indexRange = null): Node => {
-  if (!node.children) {
+  if (!node || !node.children) {
     return null
   }
 
@@ -184,6 +187,8 @@ export const _findChildWithClosestIndex = (node, index, indexRange = null): Node
 }
 
 export const isNodeInTree = (nodeId: string, tree: object): boolean => {
+  if (!nodeId || !tree) return false
+
   let nodeInTree = false
 
   const _isNodeInTree = (tree): void => {
@@ -222,6 +227,8 @@ export const getNodesFromTree = (tree: object): Node[] => {
     })
   }
 
-  _getNodesFromTree(tree, undefined)
+  if (tree) {
+    _getNodesFromTree(tree, undefined)
+  }
   return nodes
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Library should gently handle wrong parameters provided to API methods simply by skipping such methods execution. This allows to keep navigation tree structure coherent and user's code not interrupted unexpectedly.

## Description
<!--- Describe your changes in detail -->
There might be cases that LRUD library exported methods may be used with inappropriate parameters. There's no any specific scenario. The `undefined` or `null` values can always happen. In such situations LRUD library should gently ignore them and skip method execution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Library should provide coherent and error free API. There are many other places where not defined values are gently skipped, keeping the navigation tree structure coherent and user code not interrupted unexpectedly (usually by NPE). Such safe checks should be applied in all methods that are exported.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
Tested by unit tests and manually in app using LRUD library where such issue was found.

## Screenshots (if appropriate):
No screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
