### PR TITLE
insertTree: Maintain active children if requested

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1036,7 +1036,7 @@ export class Lrud {
    * @param {boolean} [options.maintainIndex] - if true, and new tree is replacing an existing branch of the tree,
    *                                            maintain the original branches relative index; default: true
    */
-  insertTree (subTreeRootNodeConfig: NodeConfig, options: InsertTreeOptions = { maintainIndex: true }): void {
+  insertTree (subTreeRootNodeConfig: NodeConfig, options: InsertTreeOptions = { maintainIndex: true, maintainActiveChildren: false }): void {
     if (!subTreeRootNodeConfig) {
       return
     }
@@ -1051,6 +1051,14 @@ export class Lrud {
     }
 
     this.registerTree(subTreeRootNodeConfig)
+
+    if (options.maintainActiveChildren) {
+      traverseNodeSubtree(subTreeRootNodeConfig, traversedNodeConfig => {
+        if (traversedNodeConfig.activeChild) {
+          this.getNode(traversedNodeConfig.id).activeChild = this.getNode(traversedNodeConfig.activeChild)
+        }
+      })
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,7 +1055,10 @@ export class Lrud {
     if (options.maintainActiveChildren) {
       traverseNodeSubtree(subTreeRootNodeConfig, traversedNodeConfig => {
         if (traversedNodeConfig.activeChild) {
-          this.getNode(traversedNodeConfig.id).activeChild = this.getNode(traversedNodeConfig.activeChild)
+          this.getNode(traversedNodeConfig.id).activeChild = this.getNode(
+            typeof traversedNodeConfig.activeChild === 'string'
+              ? traversedNodeConfig.activeChild
+              : traversedNodeConfig.activeChild.id)
         }
       })
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,7 +60,7 @@ export interface Node extends Tree<Node> {
 export interface NodeConfig extends Tree<NodeConfig>, Omit<Node, 'id'|'parent'|'activeChild'|'children'|'overrides'|'overrideSources'> {
   id?: NodeId
   parent?: NodeId
-  activeChild?: NodeId
+  activeChild?: NodeId | Node
 }
 
 export type NodesBag = { [id in NodeId]: Node }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,6 +60,7 @@ export interface Node extends Tree<Node> {
 export interface NodeConfig extends Tree<NodeConfig>, Omit<Node, 'id'|'parent'|'activeChild'|'children'|'overrides'|'overrideSources'> {
   id?: NodeId
   parent?: NodeId
+  activeChild?: NodeId
 }
 
 export type NodesBag = { [id in NodeId]: Node }
@@ -75,6 +76,7 @@ export interface HandleKeyEventOptions {
 
 export interface InsertTreeOptions {
   maintainIndex?: boolean
+  maintainActiveChildren?: boolean
 }
 
 export interface UnregisterNodeOptions {


### PR DESCRIPTION
## Description
Adds the `maintainActiveChildren` option to `insertTree()`. If enabled, any active children specified in the `subTreeRootNodeConfig` will be assigned once the tree is registered.

## Motivation and Context
I have a use-case where I want to cache a tree and then restore it at a later date. When I do so, I need the tree to maintain any previously-activated children so the page layout is maintained. I do not want to trigger an `activeChild` event, I need the children to be silently re-activated as the tree is re-registered.

## How Has This Been Tested?
I have an example of this code running in the demo for [bbc/react-lrud-cache-route](https://github.com/bbc/react-lrud-cache-route). All existing jest tests pass.

I have defaulted the `maintainActiveChildren` to `false` so it will not affect any current users of this library.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [*] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [*] I have added tests to cover my changes.
- [*] All new and existing tests passed.

* In progress