### PR TITLE
Trigger callbacks and events on focus/blur within

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,6 +156,18 @@ If given, the `onFocus` function will be called when the node gets focussed on.
 
 If given, the `onBlur` function will be called when the node if the node had focus and a new node gains focus.
 
+### `onFocusWithin`
+
+`function`
+
+If given, the `onFocusWithin` function will be called when any of the nested children of the node gains focus, and none had focus before. I.e. focus has moved into the parent.
+
+### `onBlurWithin`
+
+`function`
+
+If given, the `onBlurWithin` function will be called when the node if one of the nested children of the node had focus, and now none of them do. I.e. focus has move out of the parent.
+
 ### `onSelect`
 
 `function`
@@ -308,6 +320,28 @@ navigation.on('move', moveEvent => {
   focusedDomNode.classList.add('focused');
 })
 
+```
+
+The following two events occur when focus moves into/out of a parent node:
+* `navigation.on('focusWithin', function)` - Focus was given to a nested child node.
+* `navigation.on('blurWithin', function)` - Focus was taken from all nested child nodes.
+
+The `focusWithin` event callback is called with an event like so:
+
+```js
+{
+    node: <node>        // the node that focus has moved into
+    focusNode: <node>   // the child node that has gained focus
+}
+```
+
+The `blurWithin` event callback is called with an event like so:
+
+```js
+{
+    node: <node>        // the node that focus has moved outside of
+    blurNode: <node>    // the child node that has lost focus
+}
 ```
 
 To unregister an event callback, simply call the .off() method

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,6 +54,8 @@ export interface Node extends Tree<Node> {
   onActiveChildChange?: (event: { node: Node, leave: Node, enter: Node }) => void
   onBlur?: (node: Node) => void
   onFocus?: (node: Node) => void
+  onFocusWithin?: (node: Node, focusNode: Node) => void
+  onBlurWithin?: (node: Node, blurNode: Node) => void
   onMove?: (event: { node: Node, leave: Node, enter: Node, direction: Direction, offset: -1 | 1 }) => void
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -267,6 +267,8 @@ export const prepareNode = (nodeId: NodeId, nodeConfig: NodeConfig = {}): Node =
     onActiveChildChange: nodeConfig.onActiveChildChange,
     onBlur: nodeConfig.onBlur,
     onFocus: nodeConfig.onFocus,
+    onBlurWithin: nodeConfig.onBlurWithin,
+    onFocusWithin: nodeConfig.onFocusWithin,
     onMove: nodeConfig.onMove
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `onFocusWithin` and `onBlurWithin` functions, and the `focusWithin` and `blurWithin` events. These are triggered when focus moved into/out of a parent node.

Consider the following tree:
```
root
|-- alpha
|   |-- alpha_1
|-- bravo
|   |-- bravo_1
```

Focus is first assigned to `alpha_1`. This triggers `focusWithin` events for `alpha` and `root`. When focus moves to `bravo_1`, a `blurWithin` event is triggered for `alpha`, and a `focusWithin` event is triggered for `bravo`. No further events are triggered for `root` as focus remains within it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #96 for an example of the issue this solves. I did not want to adjust the way activation works as this will break the TAL specification, and may potentially be a breaking change for some projects. Instead, I propose these new events to allow people to track the movement of focus between parents.

Resolves: #96 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of the tests you ran to see how your change -->
<!--- affects other areas of the code, etc. -->
All current tests pass and I have added additional tests for these callbacks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
